### PR TITLE
Fix features declarations

### DIFF
--- a/src/rgsl.rs
+++ b/src/rgsl.rs
@@ -58,6 +58,8 @@ Here is the list of all modules :
 #![feature(core)]
 #![feature(libc)]
 #![feature(collections)]
+#![feature(core_intrinsics)]
+#![feature(vec_from_raw_buf)]
 
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Hi, this fix was required to build project with c_vec = 1.0, rustc = 1.3.0 nightly.