### PR TITLE
add link attributes

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -22,6 +22,8 @@ pub trait FFI<T> {
     fn unwrap(&Self) -> *mut T;
 }
 
+#[link(name ="gsl")]
+#[link(name ="gslcblas")]
 extern "C" {
     pub static gsl_rng_mt19937 : *const gsl_rng_type;
     pub static gsl_rng_ranlxs0 : *const gsl_rng_type;


### PR DESCRIPTION
This one only adds link attributtes on ffi.rs. I did not test it on Linux yet, let travis ci do it.