### PR TITLE
Remove dependency on the num crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ license = "GPL-3.0+"
 
 [dependencies]
 c_vec = "~1.0"
-num = "~0.1"
 libc = "~0.2"
 
 [lib]

--- a/examples/integration.rs
+++ b/examples/integration.rs
@@ -3,9 +3,6 @@
 //
 
 extern crate rgsl;
-extern crate num;
-
-use num::Float;
 
 struct FParams {
     // Amplitude
@@ -28,7 +25,7 @@ fn qags_fn(x: f64, alpha: &mut f64) -> f64 {
 }
 
 /* f458(x) = 1/(1 + log(x)^2)^2 */
-/* integ(log(x) f458(x),x,0,1) = (Ci(1) sin(1) + (pi/2 - Si(1)) cos(1))/pi 
+/* integ(log(x) f458(x),x,0,1) = (Ci(1) sin(1) + (pi/2 - Si(1)) cos(1))/pi
                                = -0.1892752 */
 #[allow(unused_variables)]
 fn f458<T>(x: f64, params: &mut T) -> f64 {
@@ -37,7 +34,7 @@ fn f458<T>(x: f64, params: &mut T) -> f64 {
     } else {
         let u = x.ln();
         let v = 1f64 + u * u;
-      
+
         1f64 / (v * v)
     }
 }
@@ -47,7 +44,7 @@ fn main() {
     let mut result = 0f64;
     let mut error = 0f64;
     let mut n_eval = 0;
-    
+
     let xlow = 0f64;
     let xhigh = 10f64;
     let eps_abs = 1e-4f64;
@@ -119,7 +116,7 @@ fn main() {
         let expected = -4f64;
         let mut alpha = 1f64;
 
-        w.qags(qags_fn, &mut alpha, 0f64, 1f64, 0f64, 1e-7f64, 1000, &mut result, &mut error); 
+        w.qags(qags_fn, &mut alpha, 0f64, 1f64, 0f64, 1e-7f64, 1000, &mut result, &mut error);
 
         println!("result          = {:.18}", result);
         println!("exact result    = {:.18}", expected);

--- a/examples/monte_carlo.rs
+++ b/examples/monte_carlo.rs
@@ -4,24 +4,22 @@
 
 // The example program below uses the Monte Carlo routines to estimate the value of the following 3-dimensional integral from the theory of
 // random walks,
-// 
-// I = \int_{-pi}^{+pi} {dk_x/(2 pi)} 
-//     \int_{-pi}^{+pi} {dk_y/(2 pi)} 
-//     \int_{-pi}^{+pi} {dk_z/(2 pi)} 
+//
+// I = \int_{-pi}^{+pi} {dk_x/(2 pi)}
+//     \int_{-pi}^{+pi} {dk_y/(2 pi)}
+//     \int_{-pi}^{+pi} {dk_z/(2 pi)}
 //      1 / (1 - cos(k_x)cos(k_y)cos(k_z)).
 // The analytic value of this integral can be shown to be I = \Gamma(1/4)^4/(4 \pi^3) = 1.393203929685676859.... The integral gives the mean
 // time spent at the origin by a random walk on a body-centered cubic lattice in three dimensions.
-// 
+//
 // For simplicity we will compute the integral over the region (0,0,0) to (\pi,\pi,\pi) and multiply by 8 to obtain the full result. The
 // integral is slowly varying in the middle of the region but has integrable singularities at the corners (0,0,0), (0,\pi,\pi), (\pi,0,\pi)
 // and (\pi,\pi,0). The Monte Carlo routines only select points which are strictly within the integration region and so no special measures
 // are needed to avoid these singularities.
 
 extern crate rgsl;
-extern crate num;
 
 use std::f64::consts::PI;
-use num::Float;
 
 /* Computation of the integral,
 
@@ -34,7 +32,7 @@ use num::Float;
    paper M.L.Glasser, I.J.Zucker, Proc.Natl.Acad.Sci.USA 74
    1800 (1977) */
 
-/* For simplicity we compute the integral over the region 
+/* For simplicity we compute the integral over the region
    (0,0,0) -> (pi,pi,pi) and multiply by 8 */
 
 const EXACT : f64 = 1.3932039296856768591842462603255f64;
@@ -42,7 +40,7 @@ const EXACT : f64 = 1.3932039296856768591842462603255f64;
 #[allow(unused_variables)]
 fn g(k: &mut [f64], params: &mut f64) -> f64 {
     let a = 1f64 / (PI * PI * PI);
-    
+
     a / (1.0 - k[0].cos() * k[1].cos() * k[2].cos())
 }
 
@@ -70,14 +68,14 @@ fn main() {
 
     {
         let s = rgsl::PlainMonteCarlo::new(3).unwrap();
-        
+
         s.integrate(g, &mut 0f64, &xl, &xu, calls, &r, &mut res, &mut err);
         display_results("plain", res, err);
     }
 
     {
         let s = rgsl::MiserMonteCarlo::new(3).unwrap();
-        
+
         s.integrate(g, &mut 0f64, &xl, &xu, calls, &r, &mut res, &mut err);
         display_results("miser", res, err);
     }

--- a/examples/multifit_solver.rs
+++ b/examples/multifit_solver.rs
@@ -5,14 +5,14 @@
 // The following example program fits a weighted exponential model with background to experimental data, Y = A \exp(-\lambda t) + b. The
 // first part of the program sets up the functions expb_f and expb_df to calculate the model and its Jacobian. The appropriate fitting
 // function is given by,
-// 
+//
 // f_i = ((A \exp(-\lambda t_i) + b) - y_i)/\sigma_i
 // where we have chosen t_i = i. The Jacobian matrix J is the derivative of these functions with respect to the three parameters (A,
 // \lambda, b). It is given by,
-// 
+//
 // J_{ij} = d f_i / d x_j
 // where x_0 = A, x_1 = \lambda and x_2 = b.
-// 
+//
 // expfit.c -- model functions for exponential + background */
 
 /*
@@ -50,9 +50,6 @@ the range of validity for Gaussian errors.
 #![allow(non_snake_case)]
 
 extern crate rgsl;
-extern crate num;
-
-use num::Float;
 
 struct Data {
     n: usize,
@@ -88,8 +85,8 @@ fn expb_df(x: &rgsl::VectorF64, data: &mut Data, J: &mut rgsl::MatrixF64) -> rgs
         let t = i as f64;
         let s = data.sigma[i as usize];
         let e = (-lambda * t).exp();
-      
-        J.set(i, 0, e / s); 
+
+        J.set(i, 0, e / s);
         J.set(i, 1, -t * A * e / s);
         J.set(i, 2, 1f64 / s);
     }
@@ -175,10 +172,10 @@ fn main() {
 
     rgsl::multifit::covar(&s.j, 0f64, &mut covar);
 
-    { 
+    {
         let chi = rgsl::blas::level1::dnrm2(&s.f);
         let dof = n as f64 - p as f64;
-        let c = 1f64.max(chi / dof.sqrt()); 
+        let c = 1f64.max(chi / dof.sqrt());
 
         println!("chisq/dof = {}",  chi.powf(2f64) / dof);
 

--- a/examples/radix.rs
+++ b/examples/radix.rs
@@ -8,9 +8,6 @@
 // The second part is Here is an example which computes the FFT of a short pulse in a sample of length 630 (=2*3*3*5*7) using the mixed-radix algorithm.
 
 extern crate rgsl;
-extern crate num;
-
-use num::Float;
 
 fn main() {
     /* Part 1 */

--- a/examples/wavelet_transforms.rs
+++ b/examples/wavelet_transforms.rs
@@ -6,12 +6,10 @@
 // size are ordered lexicographically.
 
 extern crate rgsl;
-extern crate num;
 
 use std::fs::File;
 use std::io::Read;
 use rgsl::{wavelet_transforms, sort};
-use num::Float;
 
 pub const N : usize = 256;
 pub const NC : usize = 20;

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -8,20 +8,20 @@
 Each algorithm computes an approximation to a definite integral of the form,
 
 I = \int_a^b f(x) w(x) dx
-where w(x) is a weight function (for general integrands w(x)=1). The user provides absolute and relative error bounds (epsabs, epsrel) which 
+where w(x) is a weight function (for general integrands w(x)=1). The user provides absolute and relative error bounds (epsabs, epsrel) which
 specify the following accuracy requirement,
 
 |RESULT - I|  <= max(epsabs, epsrel |I|)
 
-where RESULT is the numerical approximation obtained by the algorithm. The algorithms attempt to estimate the absolute error ABSERR = |RESULT 
+where RESULT is the numerical approximation obtained by the algorithm. The algorithms attempt to estimate the absolute error ABSERR = |RESULT
 - I| in such a way that the following inequality holds,
 
 |RESULT - I| <= ABSERR <= max(epsabs, epsrel |I|)
 
 In short, the routines return the first approximation which has an absolute error smaller than epsabs or a relative error smaller than epsrel.
 
-Note that this is an either-or constraint, not simultaneous. To compute to a specified absolute error, set epsrel to zero. To compute to a 
-specified relative error, set epsabs to zero. The routines will fail to converge if the error bounds are too stringent, but always return the 
+Note that this is an either-or constraint, not simultaneous. To compute to a specified absolute error, set epsrel to zero. To compute to a
+specified relative error, set epsabs to zero. The routines will fail to converge if the error bounds are too stringent, but always return the
 best approximation obtained up to that stage.
 
 The algorithms in QUADPACK use a naming convention based on the following letters,
@@ -40,49 +40,48 @@ I - infinite range of integration
 O - oscillatory weight function, cos or sin
 F - Fourier integral
 C - Cauchy principal value
-The algorithms are built on pairs of quadrature rules, a higher order rule and a lower order rule. The higher order rule is used to compute the 
-best approximation to an integral over a small range. The difference between the results of the higher order rule and the lower order rule gives 
+The algorithms are built on pairs of quadrature rules, a higher order rule and a lower order rule. The higher order rule is used to compute the
+best approximation to an integral over a small range. The difference between the results of the higher order rule and the lower order rule gives
 an estimate of the error in the approximation.
 
- * [Integrands without weight functions](http://www.gnu.org/software/gsl/manual/html_node/Integrands-without-weight-functions.html#Integrands-without-weight-functions)   
+ * [Integrands without weight functions](http://www.gnu.org/software/gsl/manual/html_node/Integrands-without-weight-functions.html#Integrands-without-weight-functions)
  * [Integrands with weight functions](http://www.gnu.org/software/gsl/manual/html_node/Integrands-with-weight-functions.html#Integrands-with-weight-functions)
  * [Integrands with singular weight functions](http://www.gnu.org/software/gsl/manual/html_node/Integrands-with-singular-weight-functions.html#Integrands-with-singular-weight-functions)
 
 ##QNG non-adaptive Gauss-Kronrod integration
 
-The QNG algorithm is a non-adaptive procedure which uses fixed Gauss-Kronrod-Patterson abscissae to sample the integrand at a maximum of 87 
+The QNG algorithm is a non-adaptive procedure which uses fixed Gauss-Kronrod-Patterson abscissae to sample the integrand at a maximum of 87
 points. It is provided for fast integration of smooth functions.
 
 ##QAG adaptive integration
 
-The QAG algorithm is a simple adaptive integration procedure. The integration region is divided into subintervals, and on each iteration the 
-subinterval with the largest estimated error is bisected. This reduces the overall error rapidly, as the subintervals become concentrated 
-around local difficulties in the integrand. These subintervals are managed by a gsl_integration_workspace struct, which handles the memory 
+The QAG algorithm is a simple adaptive integration procedure. The integration region is divided into subintervals, and on each iteration the
+subinterval with the largest estimated error is bisected. This reduces the overall error rapidly, as the subintervals become concentrated
+around local difficulties in the integrand. These subintervals are managed by a gsl_integration_workspace struct, which handles the memory
 for the subinterval ranges, results and error estimates.
 
 ##QAGS adaptive integration with singularities
 
-The presence of an integrable singularity in the integration region causes an adaptive routine to concentrate new subintervals around the 
-singularity. As the subintervals decrease in size the successive approximations to the integral converge in a limiting fashion. This 
-approach to the limit can be accelerated using an extrapolation procedure. The QAGS algorithm combines adaptive bisection with the Wynn 
+The presence of an integrable singularity in the integration region causes an adaptive routine to concentrate new subintervals around the
+singularity. As the subintervals decrease in size the successive approximations to the integral converge in a limiting fashion. This
+approach to the limit can be accelerated using an extrapolation procedure. The QAGS algorithm combines adaptive bisection with the Wynn
 epsilon-algorithm to speed up the integration of many types of integrable singularities.
 
 ##References and Further Reading
 
-The following book is the definitive reference for QUADPACK, and was written by the original authors. It provides descriptions of the 
-algorithms, program listings, test programs and examples. It also includes useful advice on numerical integration and many references 
+The following book is the definitive reference for QUADPACK, and was written by the original authors. It provides descriptions of the
+algorithms, program listings, test programs and examples. It also includes useful advice on numerical integration and many references
 to the numerical integration literature used in developing QUADPACK.
 
 R. Piessens, E. de Doncker-Kapenga, C.W. Ueberhuber, D.K. Kahaner. QUADPACK A subroutine package for automatic integration Springer Verlag, 1983.
 The CQUAD integration algorithm is described in the following paper:
 
-P. Gonnet, “Increasing the Reliability of Adaptive Quadrature Using Explicit Interpolants”, ACM Transactions on Mathematical Software, Volume 37 
+P. Gonnet, “Increasing the Reliability of Adaptive Quadrature Using Explicit Interpolants”, ACM Transactions on Mathematical Software, Volume 37
 (2010), Issue 3, Article 26.
 !*/
 
 use ffi;
 use enums;
-use num::Float;
 use std::ffi::CString;
 
 fn rescale_error(err: f64, result_abs: f64, result_asc: f64) -> f64 {
@@ -90,7 +89,7 @@ fn rescale_error(err: f64, result_abs: f64, result_asc: f64) -> f64 {
 
     if result_asc != 0f64 && t_err != 0f64 {
         let scale = unsafe { (200f64 * t_err / result_asc).powf(1.5f64) };
-        
+
         if scale < 1f64 {
             t_err = result_asc * scale;
         } else {
@@ -363,7 +362,7 @@ pub fn qng<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, eps_abs: f64, eps_r
     for k in 0usize..11usize {
         let abscissa = half_length * x3[k];
         let fval = f(center + abscissa, arg) + f(center - abscissa, arg);
-      
+
         res43 += fval * w43b[k];
         savfun[k + 10] = fval;
     }
@@ -394,7 +393,7 @@ pub fn qng<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, eps_abs: f64, eps_r
     // test for convergence
     result_kronrod = res87 * half_length ;
     err = rescale_error((res87 - res43) * half_length, resabs, resasc);
-  
+
     if err < eps_abs || err < eps_rel * unsafe { result_kronrod.abs() } {
         *result = result_kronrod;
         *abs_err = err;
@@ -425,7 +424,7 @@ pub fn qk15<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, result: &mut f64, 
         0.000000000000000000000000000000000f64
     ];
 
-    // xgk[1], xgk[3], ... abscissae of the 7-point gauss rule. 
+    // xgk[1], xgk[3], ... abscissae of the 7-point gauss rule.
     // xgk[0], xgk[2], ... abscissae to optimally extend the 7-point gauss rule
 
     // weights of the 7-point gauss rule
@@ -894,37 +893,37 @@ pub fn qk<T>(xgk: &[f64], wg: &[f64], wgk: &[f64], fv1: &mut [f64], fv2: &mut [f
 }
 
 /// This function attempts to compute a Fourier integral of the function f over the semi-infinite interval [a,+\infty).
-/// 
+///
 /// I = \int_a^{+\infty} dx f(x) sin(omega x)
 /// I = \int_a^{+\infty} dx f(x) cos(omega x)
-/// 
+///
 /// The parameter \omega and choice of \sin or \cos is taken from the table wf (the length L can take any value, since it is overridden by
 /// this function to a value appropriate for the Fourier integration). The integral is computed using the QAWO algorithm over each of the
 /// subintervals,
-/// 
+///
 /// C_1 = [a, a + c]
 /// C_2 = [a + c, a + 2 c]
 /// ... = ...
 /// C_k = [a + (k-1) c, a + k c]
-/// 
+///
 /// where c = (2 floor(|\omega|) + 1) \pi/|\omega|. The width c is chosen to cover an odd number of periods so that the contributions from
 /// the intervals alternate in sign and are monotonically decreasing when f is positive and monotonically decreasing. The sum of this sequence
 /// of contributions is accelerated using the epsilon-algorithm.
-/// 
+///
 /// This function works to an overall absolute tolerance of abserr. The following strategy is used: on each interval C_k the algorithm tries
 /// to achieve the tolerance
-/// 
+///
 /// TOL_k = u_k abserr
-/// 
+///
 /// where u_k = (1 - p)p^{k-1} and p = 9/10. The sum of the geometric series of contributions from each interval gives an overall tolerance
 /// of abserr.
-/// 
+///
 /// If the integration of a subinterval leads to difficulties then the accuracy requirement for subsequent intervals is relaxed,
-/// 
+///
 /// TOL_k = u_k max(abserr, max_{i<k}{E_i})
-/// 
+///
 /// where E_k is the estimated error on the interval C_k.
-/// 
+///
 /// The subintervals and their results are stored in the memory provided by workspace. The maximum number of subintervals is given by limit,
 /// which may not exceed the allocated size of the workspace. The integration over each subinterval uses the memory provided by cycle_workspace
 /// as workspace for the QAWO algorithm.

--- a/src/rgsl.rs
+++ b/src/rgsl.rs
@@ -55,7 +55,6 @@
 
 extern crate libc;
 extern crate c_vec;
-extern crate num;
 
 pub use types::{
     ComplexF32,

--- a/src/types/chebyshev.rs
+++ b/src/types/chebyshev.rs
@@ -5,9 +5,9 @@
 /*!
 #Chebyshev Approximations
 
-This chapter describes routines for computing Chebyshev approximations to univariate functions. A Chebyshev approximation is a truncation of the 
-series f(x) = \sum c_n T_n(x), where the Chebyshev polynomials T_n(x) = \cos(n \arccos x) provide an orthogonal basis of polynomials on the 
-interval [-1,1] with the weight function 1 / \sqrt{1-x^2}. The first few Chebyshev polynomials are, T_0(x) = 1, T_1(x) = x, T_2(x) = 2 x^2 - 1. 
+This chapter describes routines for computing Chebyshev approximations to univariate functions. A Chebyshev approximation is a truncation of the
+series f(x) = \sum c_n T_n(x), where the Chebyshev polynomials T_n(x) = \cos(n \arccos x) provide an orthogonal basis of polynomials on the
+interval [-1,1] with the weight function 1 / \sqrt{1-x^2}. The first few Chebyshev polynomials are, T_0(x) = 1, T_1(x) = x, T_2(x) = 2 x^2 - 1.
 For further information see Abramowitz & Stegun, Chapter 22.
 
 ##Definitions
@@ -27,7 +27,6 @@ R. Broucke, “Ten Subroutines for the Manipulation of Chebyshev Series [C1] (Al
 use ffi;
 use enums;
 use std::f64::consts::PI;
-use num::Float;
 use c_vec::CSlice;
 
 pub struct ChebSeries {

--- a/src/types/integration.rs
+++ b/src/types/integration.rs
@@ -6,7 +6,6 @@
 
 use ffi;
 use enums;
-use num::Float;
 use c_vec::CSlice;
 
 static XI : [f64; 33] = [
@@ -1373,22 +1372,22 @@ impl IntegrationWorkspace {
     /// This function applies an integration rule adaptively until an estimate of the integral of f over (a,b) is achieved within the desired
     /// absolute and relative error limits, epsabs and epsrel. The function returns the final approximation, result, and an estimate of the
     /// absolute error, abserr. The integration rule is determined by the value of key, which should be chosen from the following symbolic names,
-    /// 
+    ///
     /// GSL_INTEG_GAUSS15  (key = 1)
-    /// 
+    ///
     /// GSL_INTEG_GAUSS21  (key = 2)
-    /// 
+    ///
     /// GSL_INTEG_GAUSS31  (key = 3)
-    /// 
+    ///
     /// GSL_INTEG_GAUSS41  (key = 4)
-    /// 
+    ///
     /// GSL_INTEG_GAUSS51  (key = 5)
-    /// 
+    ///
     /// GSL_INTEG_GAUSS61  (key = 6)
-    /// 
+    ///
     /// corresponding to the 15f64, 21f64, 31f64, 41f64, 51 and 61 point Gauss-Kronrod rules. The higher-order rules give better accuracy for smooth functions,
     /// while lower-order rules save time when the function contains local difficulties, such as discontinuities.
-    /// 
+    ///
     /// On each iteration the adaptive integration strategy bisects the interval with the largest error estimate. The subintervals and their
     /// results are stored in the memory provided by workspace. The maximum number of subintervals is given by limit, which may not exceed the
     /// allocated size of the workspace.
@@ -1447,14 +1446,14 @@ impl IntegrationWorkspace {
     /// pts of length npts should contain the endpoints of the integration ranges defined by the integration region and locations of the singularities.
     /// For example, to integrate over the region (a,b) with break-points at x_1, x_2, x_3 (where a < x_1 < x_2 < x_3 < b) the following pts array
     /// should be used
-    /// 
+    ///
     /// pts[0] = a
     /// pts[1] = x_1
     /// pts[2] = x_2
     /// pts[3] = x_3
     /// pts[4] = b
     /// with npts = 5.
-    /// 
+    ///
     /// If you know the locations of the singular points in the integration region then this routine will be faster than QAGS.
     pub fn qagp<T>(&self, f: ::function<T>, arg: &mut T, pts: &mut [f64], epsabs: f64, epsrel: f64, limit: usize, result: &mut f64,
         abserr: &mut f64) -> ::Value {
@@ -1463,10 +1462,10 @@ impl IntegrationWorkspace {
 
     /// This function computes the integral of the function f over the infinite interval (-\infty,+\infty). The integral is mapped onto the
     /// semi-open interval (0,1] using the transformation x = (1-t)/t,
-    /// 
-    /// \int_{-\infty}^{+\infty} dx f(x) = 
+    ///
+    /// \int_{-\infty}^{+\infty} dx f(x) =
     ///      \int_0^1 dt (f((1-t)/t) + f((-1+t)/t))/t^2.
-    /// 
+    ///
     /// It is then integrated using the QAGS algorithm. The normal 21-point Gauss-Kronrod rule of QAGS is replaced by a 15-point rule, because
     /// the transformation can generate an integrable singularity at the origin. In this case a lower-order rule is more efficient.
     pub fn qagi<T>(&self, f: ::function<T>, arg: &mut T, epsabs: f64, epsrel: f64, limit: usize, result: &mut f64, abserr: &mut f64) -> ::Value {
@@ -1477,10 +1476,10 @@ impl IntegrationWorkspace {
 
     /// This function computes the integral of the function f over the semi-infinite interval (a,+\infty). The integral is mapped onto the
     /// semi-open interval (0,1] using the transformation x = a + (1-t)/t,
-    /// 
-    /// \int_{a}^{+\infty} dx f(x) = 
+    ///
+    /// \int_{a}^{+\infty} dx f(x) =
     ///      \int_0^1 dt f(a + (1-t)/t)/t^2
-    /// 
+    ///
     /// and then integrated using the QAGS algorithm.
     pub fn qagiu<T>(&self, f: ::function<T>, arg: &mut T, a: f64, epsabs: f64, epsrel: f64, limit: usize, result: &mut f64, abserr: &mut f64) -> ::Value {
         let mut s = InternParam{func: f, param: arg, p2: a};
@@ -1490,10 +1489,10 @@ impl IntegrationWorkspace {
 
     /// This function computes the integral of the function f over the semi-infinite interval (-\infty,b). The integral is mapped onto the semi-open
     /// interval (0,1] using the transformation x = b - (1-t)/t,
-    /// 
-    /// \int_{-\infty}^{b} dx f(x) = 
+    ///
+    /// \int_{-\infty}^{b} dx f(x) =
     ///      \int_0^1 dt f(b - (1-t)/t)/t^2
-    /// 
+    ///
     /// and then integrated using the QAGS algorithm.
     pub fn qagil<T>(&self, f: ::function<T>, arg: &mut T, b: f64, epsabs: f64, epsrel: f64, limit: usize, result: &mut f64, abserr: &mut f64) -> ::Value {
         let mut s = InternParam{func: f, param: arg, p2: b};
@@ -1502,9 +1501,9 @@ impl IntegrationWorkspace {
     }
 
     /// This function computes the Cauchy principal value of the integral of f over (a,b), with a singularity at c,
-    /// 
+    ///
     /// I = \int_a^b dx f(x) / (x - c)
-    /// 
+    ///
     /// The adaptive bisection algorithm of QAG is used, with modifications to ensure that subdivisions do not occur at the singular point x = c.
     /// When a subinterval contains the point x = c or is close to it then a special 25-point modified Clenshaw-Curtis rule is used to control
     /// the singularity. Further away from the singularity the algorithm uses an ordinary 15-point Gauss-Kronrod integration rule.
@@ -1547,7 +1546,7 @@ impl IntegrationWorkspace {
 
             if c == a || c == b {
                 rgsl_error!("cannot integrate with singularity on endpoint", ::Value::Inval);
-            }      
+            }
 
             /* perform the first integration */
             qc25c(f, arg, lower, higher, c, &mut result0, &mut abserr0, &mut err_reliable);
@@ -1589,7 +1588,7 @@ impl IntegrationWorkspace {
                 /* Bisect the subinterval with the largest error estimate */
                 self.retrieve(&mut a_i, &mut b_i, &mut r_i, &mut e_i);
 
-                let a1 = a_i; 
+                let a1 = a_i;
                 let mut b1 = 0.5 * (a_i + b_i);
                 let mut a2 = b1;
                 let b2 = b_i;
@@ -1757,7 +1756,7 @@ impl IntegrationWorkspace {
                 order.as_mut()[k as usize + 1usize] = order.as_ref()[k as usize];
                 k -= 1;
             }
-      
+
             order.as_mut()[k as usize + 1usize] = last;
 
             // Set i_max and e_max
@@ -1952,20 +1951,20 @@ pub struct IntegrationQawsTable {
 impl IntegrationQawsTable {
     /// This function allocates space for a gsl_integration_qaws_table struct describing a singular weight function W(x) with the parameters
     /// (\alpha, \beta, \mu, \nu),
-    /// 
+    ///
     /// W(x) = (x-a)^alpha (b-x)^beta log^mu (x-a) log^nu (b-x)
-    /// 
+    ///
     /// where \alpha > -1f64, \beta > -1f64, and \mu = 0, 1, \nu = 0, 1. The weight function can take four different forms depending on the values
     /// of \mu and \nu,
-    /// 
+    ///
     /// W(x) = (x-a)^alpha (b-x)^beta                   (mu = 0, nu = 0)
     /// W(x) = (x-a)^alpha (b-x)^beta log(x-a)          (mu = 1, nu = 0)
     /// W(x) = (x-a)^alpha (b-x)^beta log(b-x)          (mu = 0, nu = 1)
     /// W(x) = (x-a)^alpha (b-x)^beta log(x-a) log(b-x) (mu = 1, nu = 1)
-    /// 
+    ///
     /// The singular points (a,b) do not have to be specified until the integral is computed, where they are the endpoints of the integration
     /// range.
-    /// 
+    ///
     /// The function returns a pointer to the newly allocated table gsl_integration_qaws_table if no errors were detected, and 0 in the case
     /// of error.
     pub fn new(alpha: f64, beta: f64, mu: i32, nu: i32) -> Option<IntegrationQawsTable> {
@@ -1988,9 +1987,9 @@ impl IntegrationQawsTable {
     /// This function computes the integral of the function f(x) over the interval (a,b) with the singular weight function (x-a)^\alpha
     /// (b-x)^\beta \log^\mu (x-a) \log^\nu (b-x). The parameters of the weight function (\alpha, \beta, \mu, \nu) are taken from the
     /// table self. The integral is,
-    /// 
+    ///
     /// I = \int_a^b dx f(x) (x-a)^alpha (b-x)^beta log^mu (x-a) log^nu (b-x).
-    /// 
+    ///
     /// The adaptive bisection algorithm of QAG is used. When a subinterval contains one of the endpoints then a special 25-point modified
     /// Clenshaw-Curtis rule is used to control the singularities. For subintervals which do not include the endpoints an ordinary 15-point
     /// Gauss-Kronrod integration rule is used.
@@ -2086,7 +2085,7 @@ impl IntegrationQawsTable {
                 /* Bisect the subinterval with the largest error estimate */
                 workspace.retrieve(&mut a_i, &mut b_i, &mut r_i, &mut e_i);
 
-                let a1 = a_i; 
+                let a1 = a_i;
                 let b1 = 0.5f64 * (a_i + b_i);
                 let a2 = b1;
                 let b2 = b_i;
@@ -2186,16 +2185,16 @@ pub struct IntegrationQawoTable {
 impl IntegrationQawoTable {
     /// This function allocates space for a gsl_integration_qawo_table struct and its associated workspace describing a sine or cosine weight
     /// function W(x) with the parameters (\omega, L),
-    /// 
+    ///
     /// W(x) = sin(omega x)
     /// W(x) = cos(omega x)
-    /// 
+    ///
     /// The parameter L must be the length of the interval over which the function will be integrated L = b - a. The choice of sine or cosine
     /// is made with the parameter sine which should be chosen from one of the two following symbolic values:
-    /// 
+    ///
     /// ::Cosine
     /// ::IntegrationQawo::Sine
-    /// 
+    ///
     /// The gsl_integration_qawo_table is a table of the trigonometric coefficients required in the integration process. The parameter n determines
     /// the number of levels of coefficients that are computed. Each level corresponds to one bisection of the interval L, so that n levels are
     /// sufficient for subintervals down to the length L/2^n. The integration routine gsl_integration_qawo returns the error ::Table if the
@@ -2224,15 +2223,15 @@ impl IntegrationQawoTable {
 
     /// This function uses an adaptive algorithm to compute the integral of f over (a,b) with the weight function \sin(\omega x) or \cos(\omega x)
     /// defined by the table wf,
-    /// 
+    ///
     /// I = \int_a^b dx f(x) sin(omega x)
     /// I = \int_a^b dx f(x) cos(omega x)
-    /// 
+    ///
     /// The results are extrapolated using the epsilon-algorithm to accelerate the convergence of the integral. The function returns the final
     /// approximation from the extrapolation, result, and an estimate of the absolute error, abserr. The subintervals and their results are
     /// stored in the memory provided by workspace. The maximum number of subintervals is given by limit, which may not exceed the allocated
     /// size of the workspace.
-    /// 
+    ///
     /// Those subintervals with “large” widths d where d\omega > 4 are computed using a 25-point Clenshaw-Curtis integration rule, which handles
     /// the oscillatory behavior. Subintervals with a “small” widths where d\omega < 4 are computed using a 15-point Gauss-Kronrod integration.
     pub fn qawo<T>(&self, f: ::function<T>, arg: &mut T, a: f64, epsabs: f64, epsrel: f64, limit: usize, workspace: &IntegrationWorkspace,
@@ -2600,7 +2599,7 @@ impl ffi::FFI<ffi::gsl_integration_qawo_table> for IntegrationQawoTable {
 /// CQUAD is a new doubly-adaptive general-purpose quadrature routine which can handle most types of singularities, non-numerical function
 /// values such as Inf or NaN, as well as some divergent integrals. It generally requires more function evaluations than the integration
 /// routines in QUADPACK, yet fails less often for difficult integrands.
-/// 
+///
 /// The underlying algorithm uses a doubly-adaptive scheme in which Clenshaw-Curtis quadrature rules of increasing degree are used to compute
 /// the integral in each interval. The L_2-norm of the difference between the underlying interpolatory polynomials of two successive rules
 /// is used as an error estimate. The interval is subdivided if the difference between two successive rules is too large or a rule of maximum
@@ -2628,13 +2627,13 @@ impl CquadWorkspace {
     /// This function computes the integral of f over (a,b) within the desired absolute and relative error limits, epsabs and epsrel using
     /// the CQUAD algorithm. The function returns the final approximation, result, an estimate of the absolute error, abserr, and the number
     /// of function evaluations required, nevals.
-    /// 
+    ///
     /// The CQUAD algorithm divides the integration region into subintervals, and in each iteration, the subinterval with the largest estimated
     /// error is processed. The algorithm uses Clenshaw-Curits quadrature rules of degree 4, 8, 16 and 32 over 5, 9, 17 and 33 nodes respectively.
     /// Each interval is initialized with the lowest-degree rule. When an interval is processed, the next-higher degree rule is evaluated and
     /// an error estimate is computed based on the L_2-norm of the difference between the underlying interpolating polynomials of both rules.
     /// If the highest-degree rule has already been used, or the interpolatory polynomials differ significantly, the interval is bisected.
-    /// 
+    ///
     /// The subintervals and their results are stored in the memory provided by workspace. If the error estimate or the number of function
     /// evaluations is not needed, the pointers abserr and nevals can be set to NULL (not in rgsl).
     #[allow(unused_assignments)]
@@ -2998,7 +2997,7 @@ impl CquadWorkspace {
 
                     /* Check for divergence. */
                     (*ivr).ndiv = (*iv).ndiv + ((*iv).c[0].abs() > 0f64 && (*ivr).c[0] / (*iv).c[0] > 2f64) as i32;
-                
+
                     if (*ivr).ndiv > ndiv_max && 2i32 * (*ivr).ndiv > (*ivr).rdepth {
                         /* need copysign(INFINITY, igral) */
                         *result = if igral >= 0f64 {
@@ -3224,7 +3223,7 @@ fn i_transform<T>(t: f64, params: &mut InternParam<T>) -> f64 {
     let f = params.func;
     let x = (1f64 - t) / t;
     let y = f(x, params.param) + f(-x, params.param);
-  
+
     (y / t) / t
 }
 
@@ -3320,7 +3319,7 @@ fn intern_qag<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, epsabs: f64, eps
         // Bisect the subinterval with the largest error estimate
         f_w.retrieve(&mut a_i, &mut b_i, &mut r_i, &mut e_i);
 
-        let a1 = a_i; 
+        let a1 = a_i;
         let b1 = 0.5 * (a_i + b_i);
         let a2 = b1;
         let b2 = b_i;
@@ -3535,7 +3534,7 @@ pub unsafe fn intern_qelg(table: &mut ffi::extrapolation_table, result: &mut f64
        res3la being accessed when its elements are still undefined, so I have moved the update to this point so that its value more
        useful. */
 
-    (*table).nres = nres_orig + 1;  
+    (*table).nres = nres_orig + 1;
 
     *abserr = (*abserr).max(5f64 * ::DBL_EPSILON * (*result).abs());
 }
@@ -3561,10 +3560,10 @@ unsafe fn increase_nrmax(workspace: *mut ffi::gsl_integration_workspace) -> bool
     } else {
         last
     };
-  
+
     for k in id..(jupbnd + 1) {
         let i_max = order[(*workspace).nrmax as usize];
-      
+
         (*workspace).i = i_max ;
         if level[i_max as usize] < (*workspace).maximum_level {
             return true;
@@ -3577,7 +3576,7 @@ unsafe fn increase_nrmax(workspace: *mut ffi::gsl_integration_workspace) -> bool
 unsafe fn large_interval(workspace: *mut ffi::gsl_integration_workspace) -> bool {
     let i = (*workspace).i ;
     let level = CSlice::new((*workspace).level, i as usize + 1usize);
-  
+
     if level.as_ref()[i as usize] < (*workspace).maximum_level {
         true
     } else {
@@ -4053,7 +4052,7 @@ unsafe fn intern_qagp<T>(f: ::function<T>, arg: &mut T, pts: &mut [f64], epsabs:
 
     let positive_integrand = test_positivity(result0, resabs0);
 
-    let mut iteration = nint - 1; 
+    let mut iteration = nint - 1;
 
     loop {
         let mut a_i = 0f64;
@@ -4346,21 +4345,21 @@ fn gsl_integration_qcheb<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, cheb1
 
     /* These are the values of cos(pi*k/24) for k=1..11 needed for the Chebyshev expansion of f(x) */
     let x : [f64; 11] = [
-        0.9914448613738104f64,     
+        0.9914448613738104f64,
         0.9659258262890683f64,
-        0.9238795325112868f64,     
+        0.9238795325112868f64,
         0.8660254037844386f64,
-        0.7933533402912352f64,     
+        0.7933533402912352f64,
         0.7071067811865475f64,
-        0.6087614290087206f64,     
+        0.6087614290087206f64,
         0.5000000000000000f64,
-        0.3826834323650898f64,     
+        0.3826834323650898f64,
         0.2588190451025208f64,
         0.1305261922200516f64];
-  
+
     let center = 0.5f64 * (b + a);
     let half_length =  0.5f64 * (b - a);
-  
+
     fval[0] = 0.5f64 * f(b, arg);
     fval[12] = f(center, arg);
     fval[24] = 0.5f64 * f(a, arg);
@@ -4409,15 +4408,15 @@ fn gsl_integration_qcheb<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, cheb1
         let part1 = x[3] * v[4];
         let part2 = x[7] * v[8];
         let part3 = x[5] * v[6];
-        
+
         {
             let alam1 = v[0] + part1 + part2;
             let alam2 = x[1] * v[2] + part3 + x[9] * v[10];
-          
+
             cheb12[1] = alam1 + alam2;
             cheb12[11] = alam1 - alam2;
         }
-        
+
         {
             let alam1 = v[0] - part1 + part2;
             let alam2 = x[9] * v[2] - part3 + x[1] * v[10];
@@ -4648,7 +4647,7 @@ fn fn_qaws<T>(x: f64, p: &mut fn_qaws_params<T>) -> f64 {
     let t = p.table;
 
     let mut factor = 1f64;
-  
+
     unsafe {
         if (*t).alpha != 0f64 {
             factor *= (x - p.a).powf((*t).alpha);
@@ -4675,7 +4674,7 @@ fn fn_qaws_R<T>(x: f64, p: &mut fn_qaws_params<T>) -> f64 {
     let t = p.table;
 
     let mut factor = 1f64;
-  
+
     unsafe {
         if (*t).beta != 0f64 {
             factor *= (p.b - x).powf((*t).beta);
@@ -4694,7 +4693,7 @@ fn fn_qaws_L<T>(x: f64, p: &mut fn_qaws_params<T>) -> f64 {
     let t = p.table;
 
     let mut factor = 1f64;
-  
+
     unsafe {
         if (*t).alpha != 0f64 {
             factor *= (x - p.a).powf((*t).alpha);
@@ -4735,7 +4734,7 @@ unsafe fn qc25f<T>(f: ::function<T>, arg: &mut T, a: f64, b: f64, wf: *mut ffi::
     let center = 0.5f64 * (a + b);
     let half_length = 0.5f64 * (b - a);
     let omega = (*wf).omega ;
-  
+
     let par = omega * half_length;
 
     if par.abs() < 2f64 {

--- a/src/types/interpolation.rs
+++ b/src/types/interpolation.rs
@@ -5,28 +5,28 @@
 /*!
 #Interpolation
 
-This chapter describes functions for performing interpolation. The library provides a variety of interpolation methods, including Cubic splines 
-and Akima splines. The interpolation types are interchangeable, allowing different methods to be used without recompiling. Interpolations can 
-be defined for both normal and periodic boundary conditions. Additional functions are available for computing derivatives and integrals of 
+This chapter describes functions for performing interpolation. The library provides a variety of interpolation methods, including Cubic splines
+and Akima splines. The interpolation types are interchangeable, allowing different methods to be used without recompiling. Interpolations can
+be defined for both normal and periodic boundary conditions. Additional functions are available for computing derivatives and integrals of
 interpolating functions.
 
 These interpolation methods produce curves that pass through each datapoint. To interpolate noisy data with a smoothing curve see Basis Splines.
 
 ##Introduction
 
-Given a set of data points (x_1, y_1) \dots (x_n, y_n) the routines described in this section compute a continuous interpolating function 
-y(x) such that y(x_i) = y_i. The interpolation is piecewise smooth, and its behavior at the end-points is determined by the type of 
+Given a set of data points (x_1, y_1) \dots (x_n, y_n) the routines described in this section compute a continuous interpolating function
+y(x) such that y(x_i) = y_i. The interpolation is piecewise smooth, and its behavior at the end-points is determined by the type of
 interpolation used.
 
 ##Index Look-up and Acceleration
 
-The state of searches can be stored in a gsl_interp_accel object, which is a kind of iterator for interpolation lookups. It caches the previous 
+The state of searches can be stored in a gsl_interp_accel object, which is a kind of iterator for interpolation lookups. It caches the previous
 value of an index lookup. When the subsequent interpolation point falls in the same interval its index value can be returned immediately.
 
 ##Higher-level Interface
 
-The functions described in the previous sections required the user to supply pointers to the x and y arrays on each call. The following 
-functions are equivalent to the corresponding gsl_interp functions but maintain a copy of this data in the gsl_spline object. This removes 
+The functions described in the previous sections required the user to supply pointers to the x and y arrays on each call. The following
+functions are equivalent to the corresponding gsl_interp functions but maintain a copy of this data in the gsl_spline object. This removes
 the need to pass both xa and ya as arguments on each evaluation.
 
 ##References and Further Reading
@@ -103,11 +103,11 @@ impl Interp {
     }
 
     /// This function returns the name of the interpolation type used by interp. For example,
-    /// 
+    ///
     /// ```Rust
     /// println!("interp uses '{}' interpolation.", interp.name());
     /// ```
-    /// 
+    ///
     /// would print something like :
     ///
     /// ```Shell

--- a/src/types/minimizer.rs
+++ b/src/types/minimizer.rs
@@ -5,27 +5,27 @@
 /*!
 #One dimensional Minimization
 
-This chapter describes routines for finding minima of arbitrary one-dimensional functions. The library provides low level components for a 
-variety of iterative minimizers and convergence tests. These can be combined by the user to achieve the desired solution, with full access 
-to the intermediate steps of the algorithms. Each class of methods uses the same framework, so that you can switch between minimizers at 
-runtime without needing to recompile your program. Each instance of a minimizer keeps track of its own state, allowing the minimizers to be 
+This chapter describes routines for finding minima of arbitrary one-dimensional functions. The library provides low level components for a
+variety of iterative minimizers and convergence tests. These can be combined by the user to achieve the desired solution, with full access
+to the intermediate steps of the algorithms. Each class of methods uses the same framework, so that you can switch between minimizers at
+runtime without needing to recompile your program. Each instance of a minimizer keeps track of its own state, allowing the minimizers to be
 used in multi-threaded programs.
 
 ##Overview
 
-The minimization algorithms begin with a bounded region known to contain a minimum. The region is described by a lower bound a and an upper 
+The minimization algorithms begin with a bounded region known to contain a minimum. The region is described by a lower bound a and an upper
 bound b, with an estimate of the location of the minimum x.
 
 The value of the function at x must be less than the value of the function at the ends of the interval,
 
 f(a) > f(x) < f(b)
-This condition guarantees that a minimum is contained somewhere within the interval. On each iteration a new point x' is selected using one 
-of the available algorithms. If the new point is a better estimate of the minimum, i.e. where f(x') < f(x), then the current estimate of 
-the minimum x is updated. The new point also allows the size of the bounded interval to be reduced, by choosing the most compact set of 
-points which satisfies the constraint f(a) > f(x) < f(b). The interval is reduced until it encloses the true minimum to a desired tolerance. 
+This condition guarantees that a minimum is contained somewhere within the interval. On each iteration a new point x' is selected using one
+of the available algorithms. If the new point is a better estimate of the minimum, i.e. where f(x') < f(x), then the current estimate of
+the minimum x is updated. The new point also allows the size of the bounded interval to be reduced, by choosing the most compact set of
+points which satisfies the constraint f(a) > f(x) < f(b). The interval is reduced until it encloses the true minimum to a desired tolerance.
 This provides a best estimate of the location of the minimum and a rigorous error estimate.
 
-Several bracketing algorithms are available within a single framework. The user provides a high-level driver for the algorithm, and the library 
+Several bracketing algorithms are available within a single framework. The user provides a high-level driver for the algorithm, and the library
 provides the individual functions necessary for each of the steps. There are three main phases of the iteration. The steps are,
 
  * initialize minimizer state, s, for algorithm T
@@ -36,29 +36,29 @@ The state for the minimizers is held in a gsl_min_fminimizer struct. The updatin
 
 ##Caveats
 
-Note that minimization functions can only search for one minimum at a time. When there are several minima in the search area, the first minimum 
-to be found will be returned; however it is difficult to predict which of the minima this will be. In most cases, no error will be reported if 
+Note that minimization functions can only search for one minimum at a time. When there are several minima in the search area, the first minimum
+to be found will be returned; however it is difficult to predict which of the minima this will be. In most cases, no error will be reported if
 you try to find a minimum in an area where there is more than one.
 
-With all minimization algorithms it can be difficult to determine the location of the minimum to full numerical precision. The behavior of the 
+With all minimization algorithms it can be difficult to determine the location of the minimum to full numerical precision. The behavior of the
 function in the region of the minimum x^* can be approximated by a Taylor expansion,
 
 y = f(x^*) + (1/2) f''(x^*) (x - x^*)^2
 
-and the second term of this expansion can be lost when added to the first term at finite precision. This magnifies the error in locating x^*, 
-making it proportional to \sqrt \epsilon (where \epsilon is the relative accuracy of the floating point numbers). For functions with higher 
-order minima, such as x^4, the magnification of the error is correspondingly worse. The best that can be achieved is to converge to the limit 
+and the second term of this expansion can be lost when added to the first term at finite precision. This magnifies the error in locating x^*,
+making it proportional to \sqrt \epsilon (where \epsilon is the relative accuracy of the floating point numbers). For functions with higher
+order minima, such as x^4, the magnification of the error is correspondingly worse. The best that can be achieved is to converge to the limit
 of numerical accuracy in the function values, rather than the location of the minimum itself.
 
 ##Providing the function to minimize
 
-You must provide a continuous function of one variable for the minimizers to operate on. In order to allow for general parameters the functions 
+You must provide a continuous function of one variable for the minimizers to operate on. In order to allow for general parameters the functions
 are defined by a gsl_function data type (see [Providing the function to solve](http://www.gnu.org/software/gsl/manual/html_node/Providing-the-function-to-solve.html#Providing-the-function-to-solve)).
 
 ##Iteration
 
-The following functions drive the iteration of each algorithm. Each function performs one iteration to update the state of any minimizer of 
-the corresponding type. The same functions work for all minimizers so that different methods can be substituted at runtime without modifications 
+The following functions drive the iteration of each algorithm. Each function performs one iteration to update the state of any minimizer of
+the corresponding type. The same functions work for all minimizers so that different methods can be substituted at runtime without modifications
 to the code.
 
 ##Stopping Parameters
@@ -73,14 +73,13 @@ The handling of these conditions is under user control. The function below allow
 
 ##Minimization Algorithms
 
-The minimization algorithms described in this section require an initial interval which is guaranteed to contain a minimum—if a and b are the 
-endpoints of the interval and x is an estimate of the minimum then f(a) > f(x) < f(b). This ensures that the function has at least one minimum 
+The minimization algorithms described in this section require an initial interval which is guaranteed to contain a minimum—if a and b are the
+endpoints of the interval and x is an estimate of the minimum then f(a) > f(x) < f(b). This ensures that the function has at least one minimum
 somewhere in the interval. If a valid initial interval is used then these algorithm cannot fail, provided the function is well-behaved.
 !*/
 
 use ffi;
 use libc::{c_void, malloc, free};
-use num::Float;
 
 static REL_ERR_VAL    : f64 = 1.0e-06f64;
 static ABS_ERR_VAL    : f64 = 1.0e-10f64;
@@ -121,14 +120,14 @@ pub struct Minimizer<T> {
 impl<T> Minimizer<T> {
     /// This function returns a pointer to a newly allocated instance of a minimizer of type T. For example, the following code creates an
     /// instance of a golden section minimizer,
-    /// 
+    ///
     /// ```C
-    /// const gsl_min_fminimizer_type * T 
+    /// const gsl_min_fminimizer_type * T
     ///   = gsl_min_fminimizer_goldensection;
-    /// gsl_min_fminimizer * s 
+    /// gsl_min_fminimizer * s
     ///   = gsl_min_fminimizer_alloc (T);
     /// ```
-    /// 
+    ///
     /// If there is insufficient memory to create the minimizer then the function returns a null pointer and the error handler is invoked
     /// with an error code of ::NoMem.
     pub fn new(t: &MinimizerType<T>) -> Option<Minimizer<T>> {
@@ -154,7 +153,7 @@ impl<T> Minimizer<T> {
 
     /// This function sets, or resets, an existing minimizer s to use the function f and the initial search interval [x_lower, x_upper], with
     /// a guess for the location of the minimum x_minimum.
-    /// 
+    ///
     /// If the interval given does not contain a minimum, then the function returns an error code of ::Value::Inval.
     pub fn set(&mut self, f: ::function<T>, arg: &mut T, x_minimum: f64, x_lower: f64, x_upper: f64) -> ::Value {
         let mut f_minimum = 0f64;
@@ -203,11 +202,11 @@ impl<T> Minimizer<T> {
     }
 
     /// This function returns a pointer to the name of the minimizer. For example,
-    /// 
+    ///
     /// ```C
     /// printf("s is a '%s' minimizer\n", gsl_min_fminimizer_name (s));
     /// ```
-    /// 
+    ///
     /// would print something like s is a 'brent' minimizer.
     pub fn name(&self) -> String {
         self.type_.name.clone()
@@ -228,19 +227,19 @@ impl<T> Minimizer<T> {
         self.x_upper
     }
 
-    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the 
+    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the
     /// interval for the minimizer s.
     pub fn f_minimum(&self) -> f64 {
         self.f_minimum
     }
 
-    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the 
+    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the
     /// interval for the minimizer s.
     pub fn f_lower(&self) -> f64 {
         self.f_lower
     }
 
-    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the 
+    /// This function returns the value of the function at the current estimate of the minimum and at the upper and lower bounds of the
     /// interval for the minimizer s.
     pub fn f_upper(&self) -> f64 {
         self.f_upper
@@ -248,13 +247,13 @@ impl<T> Minimizer<T> {
 
     /// This function performs a single iteration of the minimizer s. If the iteration encounters an unexpected problem then an error code
     /// will be returned,
-    /// 
+    ///
     /// ::Value::BadFunc
     /// the iteration encountered a singular point where the function evaluated to Inf or NaN.
-    /// 
+    ///
     /// ::Value::Failure
     /// the algorithm could not improve the current best approximation or bounding interval.
-    /// 
+    ///
     /// The minimizer maintains a current best estimate of the position of the minimum at all times, and the current interval bounding the
     /// minimum. This information can be accessed with the following auxiliary functions,
     pub fn iterate(&mut self) -> ::Value {
@@ -284,7 +283,7 @@ pub struct MinimizerType<T> {
 impl<T> MinimizerType<T> {
     /// The golden section algorithm is the simplest method of bracketing the minimum of a function. It is the slowest algorithm provided
     /// by the library, with linear convergence.
-    /// 
+    ///
     /// On each iteration, the algorithm first compares the subintervals from the endpoints to the current minimum. The larger subinterval
     /// is divided in a golden section (using the famous ratio (3-\sqrt 5)/2 = 0.3189660…) and the value of the function at this new point
     /// is calculated. The new value is used with the constraint f(a') > f(x') < f(b') to a select new interval containing the minimum, by
@@ -301,7 +300,7 @@ impl<T> MinimizerType<T> {
 
     /// The Brent minimization algorithm combines a parabolic interpolation with the golden section algorithm. This produces a fast algorithm
     /// which is still robust.
-    /// 
+    ///
     /// The outline of the algorithm can be summarized as follows: on each iteration Brent’s method approximates the function using an
     /// interpolating parabola through three existing points. The minimum of the parabola is taken as a guess for the minimum. If it lies
     /// within the bounds of the current interval then the interpolating point is accepted, and used to generate a smaller interval. If the
@@ -739,7 +738,7 @@ fn quad_golden_iterate<T>(vstate: *mut c_void, f: ::function<T>, arg: &mut T, x_
             if x_eval < x_m {
                 *x_lower = x_eval;
                 *f_lower = f_eval;
-            } else {    
+            } else {
                 *x_upper = x_eval;
                 *f_upper = f_eval;
             }


### PR DESCRIPTION
The `num` crate is currently not used in any way.

PS: I'm sorry about the whitespace changes, my vim is set up to remove trailing whitespace automatically.