### PR TITLE
Use `pkg-config` to find libgsl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,14 @@ readme = "README.md"
 keywords = ["mathematics", "library", "GSL"]
 license = "GPL-3.0+"
 
+build = "build.rs"
+
 [dependencies]
 c_vec = "~1.0"
 libc = "~0.2"
+
+[build-dependencies]
+pkg-config = "0.3"
 
 [lib]
 name = "rgsl"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+extern crate pkg_config;
+
+fn main() {
+    if std::process::Command::new("pkg-config").output().is_err() {
+        println!("cargo:rustc-link-lib=gsl");
+        println!("cargo:rustc-link-lib=gslcblas");
+        return;
+    }
+
+    let lib = pkg_config::probe_library("gsl").unwrap();
+
+    if lib.version.starts_with("2.") {
+        println!(r#"cargo:rustc-cfg=feature="v2""#);
+    }
+}

--- a/src/rgsl.rs
+++ b/src/rgsl.rs
@@ -249,8 +249,3 @@ pub static NAN               : f64 = 0f64 / 0f64;
 pub static POSINF            : f64 = 1f64 / 0f64;
 pub static NEGINF            : f64 = -1f64 / 0f64;
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
-mod platform {
-    #[link(name = "gsl")] extern {}
-    #[link(name = "gslcblas")] extern {}
-}


### PR DESCRIPTION
This commit adds a `build.rs` script to find the `gsl` library location using
`pkg-config`, if available.  Furthermore, if the detected version begins
with `2.`, the feature `v2` is activated.

This makes the linking a bit more robust. Moreover, the automatic version detection is a nice convenience.