### PR TITLE
force mutability rules for vector and matrix types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "A rust binding for the GSL (the GNU scientific library)"
 repository = "https://github.com/GuillaumeGomez/rust-GSL"
-documentation = "http://rust-ci.org/GuillaumeGomez/rust-GSL/doc/rgsl/"
+documentation = "https://docs.rs/crate/GSL/"
 readme = "README.md"
 keywords = ["mathematics", "library", "GSL"]
 license = "GPL-3.0+"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -246,8 +246,8 @@ extern "C" {
     pub fn gsl_sf_bessel_zero_J0_e(s: c_uint, result: *mut gsl_sf_result) -> enums::Value;
     pub fn gsl_sf_bessel_zero_J1(s: c_uint) -> c_double;
     pub fn gsl_sf_bessel_zero_J1_e(s: c_uint, result: *mut gsl_sf_result) -> enums::Value;
-    pub fn gsl_sf_bessel_zero_Jnu(nu: f64, s: c_uint) -> c_double;
-    pub fn gsl_sf_bessel_zero_Jnu_e(nu: f64, s: c_uint, result: *mut gsl_sf_result) -> enums::Value;
+    pub fn gsl_sf_bessel_zero_Jnu(nu: c_double, s: c_uint) -> c_double;
+    pub fn gsl_sf_bessel_zero_Jnu_e(nu: c_double, s: c_uint, result: *mut gsl_sf_result) -> enums::Value;
 
     // Trigonometric Functions
     pub fn gsl_sf_sin(x: c_double) -> c_double;
@@ -1412,7 +1412,7 @@ extern "C" {
     pub fn gsl_blas_ccopy(x: *const gsl_vector_complex_float, y: *mut gsl_vector_complex_float) -> enums::Value;
     pub fn gsl_blas_zcopy(x: *const gsl_vector_complex, y: *mut gsl_vector_complex) -> enums::Value;
     pub fn gsl_blas_saxpy(alpha: c_float, x: *const gsl_vector_float, y: *mut gsl_vector_float) -> enums::Value;
-    pub fn gsl_blas_daxpy(alpha: f64, x: *const gsl_vector, y: *mut gsl_vector) -> enums::Value;
+    pub fn gsl_blas_daxpy(alpha: c_double, x: *const gsl_vector, y: *mut gsl_vector) -> enums::Value;
     pub fn gsl_blas_caxpy(alpha: gsl_complex_float, x: *const gsl_vector_complex_float, y: *mut gsl_vector_complex_float) -> enums::Value;
     pub fn gsl_blas_zaxpy(alpha: gsl_complex, x: *const gsl_vector_complex, y: *mut gsl_vector_complex) -> enums::Value;
     pub fn gsl_blas_sscal(alpha: c_float, x: *mut gsl_vector_float);
@@ -3255,8 +3255,8 @@ pub struct gsl_multiset {
 
 #[repr(C)]
 pub struct gsl_odeiv2_system {
-    pub function: extern fn(t: f64, *const f64, *mut f64, *mut c_void) -> enums::Value,
-    pub jacobian: Option<extern fn(t: f64, *const f64, *mut f64, *mut f64, *mut c_void) -> enums::Value>,
+    pub function: extern fn(t: c_double, *const c_double, *mut c_double, *mut c_void) -> enums::Value,
+    pub jacobian: Option<extern fn(t: c_double, *const c_double, *mut c_double, *mut c_double, *mut c_void) -> enums::Value>,
     pub dimension: usize,
     pub params: *mut c_void
 }

--- a/src/rgsl.rs
+++ b/src/rgsl.rs
@@ -4,7 +4,7 @@
 
 //! A __Rust__ binding for the [GSL library][] (the GNU Scientific Library).
 //!
-//! ##Installation
+//! ## Installation
 //!
 //! This binding requires the [GSL library] library to be installed.
 //!
@@ -22,7 +22,7 @@
 //! extern crate rgsl;
 //! ```
 //!
-//! ##Documentation
+//! ## Documentation
 //!
 //! You can access the __rgsl__ documentation locally, just build it:
 //!
@@ -34,7 +34,7 @@
 //! `file:///{rgsl_location}/target/doc/rgsl/index.html`
 //!
 //! You can also access the latest build of the documentation via the internet
-//! [here](http://rust-ci.org/GuillaumeGomez/rust-GSL/doc/rgsl/).
+//! [here](https://docs.rs/crate/GSL/).
 //!
 //! ## License
 //! __rust-GSL__ is a wrapper for __GSL__, therefore inherits the
@@ -248,4 +248,3 @@ pub static LOG_DBL_MAX       : f64 = 7.0978271289338397e+02;
 pub static NAN               : f64 = 0f64 / 0f64;
 pub static POSINF            : f64 = 1f64 / 0f64;
 pub static NEGINF            : f64 = -1f64 / 0f64;
-

--- a/src/types/matrix.rs
+++ b/src/types/matrix.rs
@@ -215,42 +215,42 @@ impl MatrixF64 {
 
     /// This function sets the value of the (i,j)-th element of the matrix to value.
     /// If y or x lies outside the allowed range of 0 to n1-1 and 0 to n2-1 then the error handler is invoked.
-    pub fn set(&self, y: usize, x: usize, value: f64) -> &MatrixF64 {
+    pub fn set(&mut self, y: usize, x: usize, value: f64) -> &MatrixF64 {
         unsafe { ffi::gsl_matrix_set(self.mat, y, x, value) };
         self
     }
 
     /// This function sets all the elements of the matrix to the value x.
-    pub fn set_all(&self, x: f64) -> &MatrixF64 {
+    pub fn set_all(&mut self, x: f64) -> &MatrixF64 {
         unsafe { ffi::gsl_matrix_set_all(self.mat, x) };
         self
     }
 
     /// This function sets all the elements of the matrix to zero.
-    pub fn set_zero(&self) -> &MatrixF64 {
+    pub fn set_zero(&mut self) -> &MatrixF64 {
         unsafe { ffi::gsl_matrix_set_zero(self.mat) };
         self
     }
 
     /// This function sets the elements of the matrix to the corresponding elements of the identity matrix, m(i,j) = \delta(i,j), i.e. a unit diagonal with all off-diagonal elements zero.
     /// This applies to both square and rectangular matrices.
-    pub fn set_identity(&self) -> &MatrixF64 {
+    pub fn set_identity(&mut self) -> &MatrixF64 {
         unsafe { ffi::gsl_matrix_set_identity(self.mat) };
         self
     }
 
     /// This function copies the elements of the other matrix into the self matrix. The two matrices must have the same size.
-    pub fn copy_from(&self, other: &MatrixF64) -> enums::Value {
+    pub fn copy_from(&mut self, other: &MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_memcpy(self.mat, other.mat) }
     }
 
     /// This function copies the elements of the self matrix into the other matrix. The two matrices must have the same size.
-    pub fn copy_to(&self, other: &MatrixF64) -> enums::Value {
+    pub fn copy_to(&self, other: &mut MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_memcpy(other.mat, self.mat) }
     }
 
     /// This function exchanges the elements of the matrices self and other by copying. The two matrices must have the same size.
-    pub fn swap(&self, other: &MatrixF64) -> enums::Value {
+    pub fn swap(&mut self, other: &mut MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_swap(self.mat, other.mat) }
     }
 
@@ -282,29 +282,29 @@ impl MatrixF64 {
 
     /// This function copies the elements of the vector v into the y-th row of the matrix.
     /// The length of the vector must be the same as the length of the row.
-    pub fn set_row(&self, y: usize, v: &VectorF64) -> enums::Value {
+    pub fn set_row(&mut self, y: usize, v: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_set_row(self.mat, y, ffi::FFI::unwrap(v)) }
     }
 
     /// This function copies the elements of the vector v into the x-th column of the matrix.
     /// The length of the vector must be the same as the length of the column.
-    pub fn set_col(&self, x: usize, v: &VectorF64) -> enums::Value {
+    pub fn set_col(&mut self, x: usize, v: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_set_col(self.mat, x, ffi::FFI::unwrap(v)) }
     }
 
     /// This function exchanges the y1-th and y2-th rows of the matrix in-place.
-    pub fn swap_rows(&self, y1: usize, y2: usize) -> enums::Value {
+    pub fn swap_rows(&mut self, y1: usize, y2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_swap_rows(self.mat, y1, y2) }
     }
 
     /// This function exchanges the x1-th and x2-th columns of the matrix in-place.
-    pub fn swap_columns(&self, x1: usize, x2: usize) -> enums::Value {
+    pub fn swap_columns(&mut self, x1: usize, x2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_swap_columns(self.mat, x1, x2) }
     }
 
     /// This function exchanges the i-th row and j-th column of the matrix in-place.
     /// The matrix must be square for this operation to be possible.
-    pub fn swap_row_col(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_row_col(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_swap_rowcol(self.mat, i, j) }
     }
 
@@ -324,41 +324,41 @@ impl MatrixF64 {
 
     /// This function replaces the matrix m by its transpose by copying the elements of the matrix in-place.
     /// The matrix must be square for this operation to be possible.
-    pub fn transpose(&self) -> enums::Value {
+    pub fn transpose(&mut self) -> enums::Value {
         unsafe { ffi::gsl_matrix_transpose(self.mat) }
     }
 
     /// This function adds the elements of the other matrix to the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) + other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn add(&self, other: &MatrixF64) -> enums::Value {
+    pub fn add(&mut self, other: &MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_add(self.mat, other.mat) }
     }
 
     /// This function subtracts the elements of the other matrix from the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) - other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn sub(&self, other: &MatrixF64) -> enums::Value {
+    pub fn sub(&mut self, other: &MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_sub(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) * other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn mul_elements(&self, other: &MatrixF64) -> enums::Value {
+    pub fn mul_elements(&mut self, other: &MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_mul_elements(self.mat, other.mat) }
     }
 
     /// This function divides the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) / other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn div_elements(&self, other: &MatrixF64) -> enums::Value {
+    pub fn div_elements(&mut self, other: &MatrixF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_div_elements(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the constant factor x. The result self(i,j) <- x self(i,j) is stored in self.
-    pub fn scale(&self, x: f64) -> enums::Value {
+    pub fn scale(&mut self, x: f64) -> enums::Value {
         unsafe { ffi::gsl_matrix_scale(self.mat, x) }
     }
 
     /// This function adds the constant value x to the elements of the self matrix. The result self(i,j) <- self(i,j) + x is stored in self.
-    pub fn add_constant(&self, x: f64) -> enums::Value {
+    pub fn add_constant(&mut self, x: f64) -> enums::Value {
         unsafe { ffi::gsl_matrix_add_constant(self.mat, x) }
     }
 
@@ -471,7 +471,7 @@ impl MatrixF64 {
                 None
             } else {
                 match MatrixF64::new((*self.mat).size1, (*self.mat).size2) {
-                    Some(m) => {
+                    Some(mut m) => {
                         m.copy_from(self);
                         Some(m)
                     }
@@ -567,42 +567,42 @@ impl MatrixF32 {
 
     /// This function sets the value of the (i,j)-th element of the matrix to value.
     /// If y or x lies outside the allowed range of 0 to n1-1 and 0 to n2-1 then the error handler is invoked.
-    pub fn set(&self, y: usize, x: usize, value: f32) -> &MatrixF32 {
+    pub fn set(&mut self, y: usize, x: usize, value: f32) -> &MatrixF32 {
         unsafe { ffi::gsl_matrix_float_set(self.mat, y, x, value) };
         self
     }
 
     /// This function sets all the elements of the matrix to the value x.
-    pub fn set_all(&self, x: f32) -> &MatrixF32 {
+    pub fn set_all(&mut self, x: f32) -> &MatrixF32 {
         unsafe { ffi::gsl_matrix_float_set_all(self.mat, x) };
         self
     }
 
     /// This function sets all the elements of the matrix to zero.
-    pub fn set_zero(&self) -> &MatrixF32 {
+    pub fn set_zero(&mut self) -> &MatrixF32 {
         unsafe { ffi::gsl_matrix_float_set_zero(self.mat) };
         self
     }
 
     /// This function sets the elements of the matrix to the corresponding elements of the identity matrix, m(i,j) = \delta(i,j), i.e. a unit diagonal with all off-diagonal elements zero.
     /// This applies to both square and rectangular matrices.
-    pub fn set_identity(&self) -> &MatrixF32 {
+    pub fn set_identity(&mut self) -> &MatrixF32 {
         unsafe { ffi::gsl_matrix_float_set_identity(self.mat) };
         self
     }
 
     /// This function copies the elements of the other matrix into the self matrix. The two matrices must have the same size.
-    pub fn copy_from(&self, other: &MatrixF32) -> enums::Value {
+    pub fn copy_from(&mut self, other: &MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_memcpy(self.mat, other.mat) }
     }
 
     /// This function copies the elements of the self matrix into the other matrix. The two matrices must have the same size.
-    pub fn copy_to(&self, other: &MatrixF32) -> enums::Value {
+    pub fn copy_to(&self, other: &mut MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_memcpy(other.mat, self.mat) }
     }
 
     /// This function exchanges the elements of the matrices self and other by copying. The two matrices must have the same size.
-    pub fn swap(&self, other: &MatrixF32) -> enums::Value {
+    pub fn swap(&mut self, other: &mut MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_swap(self.mat, other.mat) }
     }
 
@@ -634,28 +634,28 @@ impl MatrixF32 {
 
     /// This function copies the elements of the vector v into the y-th row of the matrix.
     /// The length of the vector must be the same as the length of the row.
-    pub fn set_row(&self, y: usize, v: &VectorF32) -> enums::Value {
+    pub fn set_row(&mut self, y: usize, v: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_set_row(self.mat, y, ffi::FFI::unwrap(v)) }
     }
 
     /// This function copies the elements of the vector v into the x-th column of the matrix.
     /// The length of the vector must be the same as the length of the column.
-    pub fn set_col(&self, x: usize, v: &VectorF32) -> enums::Value {
+    pub fn set_col(&mut self, x: usize, v: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_set_col(self.mat, x, ffi::FFI::unwrap(v)) }
     }
 
     /// This function exchanges the y1-th and y2-th rows of the matrix in-place.
-    pub fn swap_rows(&self, y1: usize, y2: usize) -> enums::Value {
+    pub fn swap_rows(&mut self, y1: usize, y2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_swap_rows(self.mat, y1, y2) }
     }
 
     /// This function exchanges the x1-th and x2-th columns of the matrix in-place.
-    pub fn swap_columns(&self, x1: usize, x2: usize) -> enums::Value {
+    pub fn swap_columns(&mut self, x1: usize, x2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_swap_columns(self.mat, x1, x2) }
     }
 
     /// This function exchanges the i-th row and j-th column of the matrix in-place. The matrix must be square for this operation to be possible.
-    pub fn swap_row_col(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_row_col(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_swap_rowcol(self.mat, i, j) }
     }
 
@@ -684,35 +684,35 @@ impl MatrixF32 {
 
     /// This function adds the elements of the other matrix to the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) + other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn add(&self, other: &MatrixF32) -> enums::Value {
+    pub fn add(&mut self, other: &MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_add(self.mat, other.mat) }
     }
 
     /// This function subtracts the elements of the other matrix from the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) - other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn sub(&self, other: &MatrixF32) -> enums::Value {
+    pub fn sub(&mut self, other: &MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_sub(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) * other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn mul_elements(&self, other: &MatrixF32) -> enums::Value {
+    pub fn mul_elements(&mut self, other: &MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_mul_elements(self.mat, other.mat) }
     }
 
     /// This function divides the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) / other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn div_elements(&self, other: &MatrixF32) -> enums::Value {
+    pub fn div_elements(&mut self, other: &MatrixF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_div_elements(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the constant factor x. The result self(i,j) <- x self(i,j) is stored in self.
-    pub fn scale(&self, x: f32) -> enums::Value {
+    pub fn scale(&mut self, x: f32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_scale(self.mat, x) }
     }
 
     /// This function adds the constant value x to the elements of the self matrix. The result self(i,j) <- self(i,j) + x is stored in self.
-    pub fn add_constant(&self, x: f32) -> enums::Value {
+    pub fn add_constant(&mut self, x: f32) -> enums::Value {
         unsafe { ffi::gsl_matrix_float_add_constant(self.mat, x) }
     }
 
@@ -809,7 +809,7 @@ impl MatrixF32 {
                 None
             } else {
                 match MatrixF32::new((*self.mat).size1, (*self.mat).size2) {
-                    Some(m) => {
+                    Some(mut m) => {
                         m.copy_from(self);
                         Some(m)
                     }

--- a/src/types/matrix_complex.rs
+++ b/src/types/matrix_complex.rs
@@ -41,42 +41,42 @@ impl MatrixComplexF64 {
 
     /// This function sets the value of the (i,j)-th element of the matrix to value.
     /// If y or x lies outside the allowed range of 0 to n1-1 and 0 to n2-1 then the error handler is invoked.
-    pub fn set(&self, y: usize, x: usize, value: &ComplexF64) -> &MatrixComplexF64 {
+    pub fn set(&mut self, y: usize, x: usize, value: &ComplexF64) -> &MatrixComplexF64 {
         unsafe { ffi::gsl_matrix_complex_set(self.mat, y, x, ::std::mem::transmute(*value)) };
         self
     }
 
     /// This function sets all the elements of the matrix to the value x.
-    pub fn set_all(&self, x: &ComplexF64) -> &MatrixComplexF64 {
+    pub fn set_all(&mut self, x: &ComplexF64) -> &MatrixComplexF64 {
         unsafe { ffi::gsl_matrix_complex_set_all(self.mat, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the matrix to zero.
-    pub fn set_zero(&self) -> &MatrixComplexF64 {
+    pub fn set_zero(&mut self) -> &MatrixComplexF64 {
         unsafe { ffi::gsl_matrix_complex_set_zero(self.mat) };
         self
     }
 
     /// This function sets the elements of the matrix to the corresponding elements of the identity matrix, m(i,j) = \delta(i,j), i.e. a unit diagonal with all off-diagonal elements zero.
     /// This applies to both square and rectangular matrices.
-    pub fn set_identity(&self) -> &MatrixComplexF64 {
+    pub fn set_identity(&mut self) -> &MatrixComplexF64 {
         unsafe { ffi::gsl_matrix_complex_set_identity(self.mat) };
         self
     }
 
     /// This function copies the elements of the other matrix into the self matrix. The two matrices must have the same size.
-    pub fn copy_from(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn copy_from(&mut self, other: &MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_memcpy(self.mat, other.mat) }
     }
 
     /// This function copies the elements of the self matrix into the other matrix. The two matrices must have the same size.
-    pub fn copy_to(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn copy_to(&self, other: &mut MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_memcpy(other.mat, self.mat) }
     }
 
     /// This function exchanges the elements of the matrices self and other by copying. The two matrices must have the same size.
-    pub fn swap(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn swap(&mut self, other: &mut MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_swap(self.mat, other.mat) }
     }
 
@@ -108,28 +108,28 @@ impl MatrixComplexF64 {
 
     /// This function copies the elements of the vector v into the y-th row of the matrix.
     /// The length of the vector must be the same as the length of the row.
-    pub fn set_row(&self, y: usize, v: &VectorComplexF64) -> enums::Value {
+    pub fn set_row(&mut self, y: usize, v: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_set_row(self.mat, y, ffi::FFI::unwrap(v)) }
     }
 
     /// This function copies the elements of the vector v into the x-th column of the matrix.
     /// The length of the vector must be the same as the length of the column.
-    pub fn set_col(&self, x: usize, v: &VectorComplexF64) -> enums::Value {
+    pub fn set_col(&mut self, x: usize, v: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_set_col(self.mat, x, ffi::FFI::unwrap(v)) }
     }
 
     /// This function exchanges the y1-th and y2-th rows of the matrix in-place.
-    pub fn swap_rows(&self, y1: usize, y2: usize) -> enums::Value {
+    pub fn swap_rows(&mut self, y1: usize, y2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_swap_rows(self.mat, y1, y2) }
     }
 
     /// This function exchanges the x1-th and x2-th columns of the matrix in-place.
-    pub fn swap_columns(&self, x1: usize, x2: usize) -> enums::Value {
+    pub fn swap_columns(&mut self, x1: usize, x2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_swap_columns(self.mat, x1, x2) }
     }
 
     /// This function exchanges the i-th row and j-th column of the matrix in-place. The matrix must be square for this operation to be possible.
-    pub fn swap_row_col(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_row_col(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_swap_rowcol(self.mat, i, j) }
     }
 
@@ -155,35 +155,35 @@ impl MatrixComplexF64 {
 
     /// This function adds the elements of the other matrix to the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) + other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn add(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn add(&mut self, other: &MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_add(self.mat, other.mat) }
     }
 
     /// This function subtracts the elements of the other matrix from the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) - other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn sub(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn sub(&mut self, other: &MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_sub(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) * other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn mul_elements(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn mul_elements(&mut self, other: &MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_mul_elements(self.mat, other.mat) }
     }
 
     /// This function divides the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) / other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn div_elements(&self, other: &MatrixComplexF64) -> enums::Value {
+    pub fn div_elements(&mut self, other: &MatrixComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_div_elements(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the constant factor x. The result self(i,j) <- x self(i,j) is stored in self.
-    pub fn scale(&self, x: &ComplexF64) -> enums::Value {
+    pub fn scale(&mut self, x: &ComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_scale(self.mat, ::std::mem::transmute(*x)) }
     }
 
     /// This function adds the constant value x to the elements of the self matrix. The result self(i,j) <- self(i,j) + x is stored in self.
-    pub fn add_constant(&self, x: &ComplexF64) -> enums::Value {
+    pub fn add_constant(&mut self, x: &ComplexF64) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_add_constant(self.mat, ::std::mem::transmute(*x)) }
     }
 
@@ -233,7 +233,7 @@ impl MatrixComplexF64 {
                 None
             } else {
                 match MatrixComplexF64::new((*self.mat).size1, (*self.mat).size2) {
-                    Some(m) => {
+                    Some(mut m) => {
                         m.copy_from(self);
                         Some(m)
                     }
@@ -321,42 +321,42 @@ impl MatrixComplexF32 {
 
     /// This function sets the value of the (i,j)-th element of the matrix to value.
     /// If y or x lies outside the allowed range of 0 to n1-1 and 0 to n2-1 then the error handler is invoked.
-    pub fn set(&self, y: usize, x: usize, value: &ComplexF32) -> &MatrixComplexF32 {
+    pub fn set(&mut self, y: usize, x: usize, value: &ComplexF32) -> &MatrixComplexF32 {
         unsafe { ffi::gsl_matrix_complex_float_set(self.mat, y, x, ::std::mem::transmute(*value)) };
         self
     }
 
     /// This function sets all the elements of the matrix to the value x.
-    pub fn set_all(&self, x: &ComplexF32) -> &MatrixComplexF32 {
+    pub fn set_all(&mut self, x: &ComplexF32) -> &MatrixComplexF32 {
         unsafe { ffi::gsl_matrix_complex_float_set_all(self.mat, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the matrix to zero.
-    pub fn set_zero(&self) -> &MatrixComplexF32 {
+    pub fn set_zero(&mut self) -> &MatrixComplexF32 {
         unsafe { ffi::gsl_matrix_complex_float_set_zero(self.mat) };
         self
     }
 
     /// This function sets the elements of the matrix to the corresponding elements of the identity matrix, m(i,j) = \delta(i,j), i.e. a unit diagonal with all off-diagonal elements zero.
     /// This applies to both square and rectangular matrices.
-    pub fn set_identity(&self) -> &MatrixComplexF32 {
+    pub fn set_identity(&mut self) -> &MatrixComplexF32 {
         unsafe { ffi::gsl_matrix_complex_float_set_identity(self.mat) };
         self
     }
 
     /// This function copies the elements of the other matrix into the self matrix. The two matrices must have the same size.
-    pub fn copy_from(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn copy_from(&mut self, other: &MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_memcpy(self.mat, other.mat) }
     }
 
     /// This function copies the elements of the self matrix into the other matrix. The two matrices must have the same size.
-    pub fn copy_to(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn copy_to(&self, other: &mut MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_memcpy(other.mat, self.mat) }
     }
 
     /// This function exchanges the elements of the matrices self and other by copying. The two matrices must have the same size.
-    pub fn swap(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn swap(&mut self, other: &mut MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_swap(self.mat, other.mat) }
     }
 
@@ -388,13 +388,13 @@ impl MatrixComplexF32 {
 
     /// This function copies the elements of the vector v into the y-th row of the matrix.
     /// The length of the vector must be the same as the length of the row.
-    pub fn set_row(&self, y: usize, v: &VectorComplexF32) -> enums::Value {
+    pub fn set_row(&mut self, y: usize, v: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_set_row(self.mat, y, ffi::FFI::unwrap(v)) }
     }
 
     /// This function copies the elements of the vector v into the x-th column of the matrix.
     /// The length of the vector must be the same as the length of the column.
-    pub fn set_col(&self, x: usize, v: &VectorComplexF32) -> enums::Value {
+    pub fn set_col(&mut self, x: usize, v: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_set_col(self.mat, x, ffi::FFI::unwrap(v)) }
     }
 
@@ -404,12 +404,12 @@ impl MatrixComplexF32 {
     }
 
     /// This function exchanges the x1-th and x2-th columns of the matrix in-place.
-    pub fn swap_columns(&self, x1: usize, x2: usize) -> enums::Value {
+    pub fn swap_columns(&mut self, x1: usize, x2: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_swap_columns(self.mat, x1, x2) }
     }
 
     /// This function exchanges the i-th row and j-th column of the matrix in-place. The matrix must be square for this operation to be possible.
-    pub fn swap_row_col(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_row_col(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_swap_rowcol(self.mat, i, j) }
     }
 
@@ -429,41 +429,41 @@ impl MatrixComplexF32 {
 
     /// This function replaces the matrix m by its transpose by copying the elements of the matrix in-place.
     /// The matrix must be square for this operation to be possible.
-    pub fn transpose(&self) -> enums::Value {
+    pub fn transpose(&mut self) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_transpose(self.mat) }
     }
 
     /// This function adds the elements of the other matrix to the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) + other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn add(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn add(&mut self, other: &MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_add(self.mat, other.mat) }
     }
 
     /// This function subtracts the elements of the other matrix from the elements of the self matrix.
     /// The result self(i,j) <- self(i,j) - other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn sub(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn sub(&mut self, other: &MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_sub(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) * other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn mul_elements(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn mul_elements(&mut self, other: &MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_mul_elements(self.mat, other.mat) }
     }
 
     /// This function divides the elements of the self matrix by the elements of the other matrix.
     /// The result self(i,j) <- self(i,j) / other(i,j) is stored in self and other remains unchanged. The two matrices must have the same dimensions.
-    pub fn div_elements(&self, other: &MatrixComplexF32) -> enums::Value {
+    pub fn div_elements(&mut self, other: &MatrixComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_div_elements(self.mat, other.mat) }
     }
 
     /// This function multiplies the elements of the self matrix by the constant factor x. The result self(i,j) <- x self(i,j) is stored in self.
-    pub fn scale(&self, x: &ComplexF32) -> enums::Value {
+    pub fn scale(&mut self, x: &ComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_scale(self.mat, ::std::mem::transmute(*x)) }
     }
 
     /// This function adds the constant value x to the elements of the self matrix. The result self(i,j) <- self(i,j) + x is stored in self.
-    pub fn add_constant(&self, x: &ComplexF32) -> enums::Value {
+    pub fn add_constant(&mut self, x: &ComplexF32) -> enums::Value {
         unsafe { ffi::gsl_matrix_complex_float_add_constant(self.mat, ::std::mem::transmute(*x)) }
     }
 
@@ -514,7 +514,7 @@ impl MatrixComplexF32 {
                 None
             } else {
                 match MatrixComplexF32::new((*self.mat).size1, (*self.mat).size2) {
-                    Some(m) => {
+                    Some(mut m) => {
                         m.copy_from(self);
                         Some(m)
                     }

--- a/src/types/rng.rs
+++ b/src/types/rng.rs
@@ -89,7 +89,7 @@ impl Rng {
     /// 
     /// The generator is automatically initialized with the default seed, gsl_rng_default_seed. This is zero by default but can be changed either directly or by using the environment variable
     /// GSL_RNG_SEED (see [`Random number environment variables`](https://www.gnu.org/software/gsl/manual/html_node/Random-number-environment-variables.html#Random-number-environment-variables)).
-    pub fn new(T: &RngType) -> Option<Rng> {
+    pub fn new(T: &mut RngType) -> Option<Rng> {
         let tmp = unsafe { ffi::gsl_rng_alloc(ffi::FFI::unwrap(T)) };
 
         if tmp.is_null() {
@@ -108,27 +108,27 @@ impl Rng {
     /// When using multiple seeds with the same generator, choose seed values greater than zero to avoid collisions with the default setting.
     /// 
     /// Note that the most generators only accept 32-bit seeds, with higher values being reduced modulo 2^32. For generators with smaller ranges the maximum seed value will typically be lower.
-    pub fn set(&self, s: usize) {
+    pub fn set(&mut self, s: usize) {
         unsafe { ffi::gsl_rng_set(self.r, s as c_ulong) }
     }
 
     /// This function returns a random integer from the generator r. The minimum and maximum values depend on the algorithm used, but all integers in the range [min,max] are equally likely.
     /// The values of min and max can be determined using the auxiliary functions gsl_rng_max (r) and gsl_rng_min (r).
-    pub fn get(&self) -> usize {
+    pub fn get(&mut self) -> usize {
         unsafe { ffi::gsl_rng_get(self.r) as usize }
     }
 
     /// This function returns a double precision floating point number uniformly distributed in the range [0,1). The range includes 0.0 but excludes 1.0.
     /// The value is typically obtained by dividing the result of gsl_rng_get(r) by gsl_rng_max(r) + 1.0 in double precision.
     /// Some generators compute this ratio internally so that they can provide floating point numbers with more than 32 bits of randomness (the maximum number of bits that can be portably represented in a single unsigned long int).
-    pub fn uniform(&self) -> f64 {
+    pub fn uniform(&mut self) -> f64 {
         unsafe { ffi::gsl_rng_uniform(self.r) }
     }
 
     /// This function returns a positive double precision floating point number uniformly distributed in the range (0,1), excluding both 0.0 and 1.0.
     /// The number is obtained by sampling the generator with the algorithm of gsl_rng_uniform until a non-zero value is obtained.
     /// You can use this function if you need to avoid a singularity at 0.0.
-    pub fn uniform_pos(&self) -> f64 {
+    pub fn uniform_pos(&mut self) -> f64 {
         unsafe { ffi::gsl_rng_uniform_pos(self.r) }
     }
 
@@ -140,7 +140,7 @@ impl Rng {
     /// 
     /// In particular, this function is not intended for generating the full range of unsigned integer values [0,2^32-1].
     /// Instead choose a generator with the maximal integer range and zero minimum value, such as gsl_rng_ranlxd1, gsl_rng_mt19937 or gsl_rng_taus, and sample it directly using gsl_rng_get. The range of each generator can be found using the auxiliary functions described in the next section.
-    pub fn uniform_int(&self, n: usize) -> usize {
+    pub fn uniform_int(&mut self, n: usize) -> usize {
         unsafe { ffi::gsl_rng_uniform_int(self.r, n as c_ulong) as usize }
     }
 
@@ -182,7 +182,7 @@ impl Rng {
     }
 
     /// This function copies the random number generator src into the pre-existing generator dest, making dest into an exact copy of src. The two generators must be of the same type.
-    pub fn copy(&self, other: &Rng) -> enums::Value {
+    pub fn copy(&self, other: &mut Rng) -> enums::Value {
         unsafe { ffi::gsl_rng_memcpy(other.r, self.r) }
     }
 

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -174,7 +174,7 @@ impl VectorF32 {
         if tmp.is_null() {
             None
         } else {
-            let v = VectorF32 {
+            let mut v = VectorF32 {
                 vec: tmp,
                 can_free: true,
             };
@@ -202,85 +202,85 @@ impl VectorF32 {
     }
 
     /// This function sets the value of the i-th element of a vector v to x. If i lies outside the allowed range of 0 to n-1 then the error handler is invoked.
-    pub fn set(&self, i: usize, x: f32) -> &VectorF32 {
+    pub fn set(&mut self, i: usize, x: f32) -> &mut VectorF32 {
         unsafe { ffi::gsl_vector_float_set(self.vec, i, x) };
         self
     }
 
     /// This function sets all the elements of the vector v to the value x.
-    pub fn set_all(&self, x: f32) -> &VectorF32 {
+    pub fn set_all(&mut self, x: f32) -> &mut VectorF32 {
         unsafe { ffi::gsl_vector_float_set_all(self.vec, x) };
         self
     }
 
     /// This function sets all the elements of the vector v to zero.
-    pub fn set_zero(&self) -> &VectorF32 {
+    pub fn set_zero(&mut self) -> &mut VectorF32 {
         unsafe { ffi::gsl_vector_float_set_zero(self.vec) };
         self
     }
 
     /// This function makes a basis vector by setting all the elements of the vector v to zero except for the i-th element which is set to one.
-    pub fn set_basis(&self, i: usize) -> &VectorF32 {
+    pub fn set_basis(&mut self, i: usize) -> &mut VectorF32 {
         unsafe { ffi::gsl_vector_float_set_basis(self.vec, i) };
         self
     }
 
     /// This function copies the elements of the other vector into the self vector. The two vectors must have the same length.
-    pub fn copy_from(&self, other: &VectorF32) -> enums::Value {
+    pub fn copy_from(&mut self, other: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_memcpy(self.vec, other.vec) }
     }
 
     /// This function copies the elements of the self vector into the other vector. The two vectors must have the same length.
-    pub fn copy_to(&self, other: &VectorF32) -> enums::Value {
+    pub fn copy_to(&self, other: &mut VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_memcpy(other.vec, self.vec) }
     }
 
     /// This function exchanges the elements of the vectors by copying. The two vectors must have the same length.
-    pub fn swap(&self, other: &VectorF32) -> enums::Value {
+    pub fn swap(&mut self, other: &mut VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_swap(other.vec, self.vec) }
     }
 
     /// This function exchanges the i-th and j-th elements of the vector v in-place.
-    pub fn swap_elements(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_elements(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_vector_float_swap_elements(self.vec, i, j) }
     }
 
     /// This function reverses the order of the elements of the vector v.
-    pub fn reverse(&self) -> enums::Value {
+    pub fn reverse(&mut self) -> enums::Value {
         unsafe { ffi::gsl_vector_float_reverse(self.vec) }
     }
 
     /// This function adds the elements of the other vector to the elements of the self vector.
     /// The result a_i <- a_i + b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn add(&self, other: &VectorF32) -> enums::Value {
+    pub fn add(&mut self, other: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_add(self.vec, other.vec) }
     }
 
     /// This function subtracts the elements of the self vector from the elements of the other vector.
     /// The result a_i <- a_i - b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn sub(&self, other: &VectorF32) -> enums::Value {
+    pub fn sub(&mut self, other: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_sub(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector a by the elements of the other vector.
     /// The result a_i <- a_i * b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn mul(&self, other: &VectorF32) -> enums::Value {
+    pub fn mul(&mut self, other: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_mul(self.vec, other.vec) }
     }
 
     /// This function divides the elements of the self vector by the elements of the other vector.
     /// The result a_i <- a_i / b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn div(&self, other: &VectorF32) -> enums::Value {
+    pub fn div(&mut self, other: &VectorF32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_div(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector by the constant factor x. The result a_i <- a_i is stored in self.
-    pub fn scale(&self, x: f32) -> enums::Value {
+    pub fn scale(&mut self, x: f32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_scale(self.vec, x) }
     }
 
     /// This function adds the constant value x to the elements of the self vector. The result a_i <- a_i + x is stored in self.
-    pub fn add_constant(&self, x: f32) -> enums::Value {
+    pub fn add_constant(&mut self, x: f32) -> enums::Value {
         unsafe { ffi::gsl_vector_float_add_constant(self.vec, x) }
     }
 
@@ -385,7 +385,7 @@ impl VectorF32 {
                 None
             } else {
                 match VectorF32::new((*self.vec).size) {
-                    Some(v) => {
+                    Some(mut v) => {
                         v.copy_from(self);
                         Some(v)
                     }
@@ -468,7 +468,7 @@ impl VectorF64 {
         if tmp.is_null() {
             None
         } else {
-            let v = VectorF64 {
+            let mut v = VectorF64 {
                 vec: tmp,
                 can_free: true
             };
@@ -496,85 +496,85 @@ impl VectorF64 {
     }
 
     /// This function sets the value of the i-th element of a vector v to x. If i lies outside the allowed range of 0 to n-1 then the error handler is invoked.
-    pub fn set(&self, i: usize, x: f64) -> &VectorF64 {
+    pub fn set(&mut self, i: usize, x: f64) -> &mut VectorF64 {
         unsafe { ffi::gsl_vector_set(self.vec, i, x) };
         self
     }
 
     /// This function sets all the elements of the vector v to the value x.
-    pub fn set_all(&self, x: f64) -> &VectorF64 {
+    pub fn set_all(&mut self, x: f64) -> &mut VectorF64 {
         unsafe { ffi::gsl_vector_set_all(self.vec, x) };
         self
     }
 
     /// This function sets all the elements of the vector v to zero.
-    pub fn set_zero(&self) -> &VectorF64 {
+    pub fn set_zero(&mut self) -> &mut VectorF64 {
         unsafe { ffi::gsl_vector_set_zero(self.vec) };
         self
     }
 
     /// This function makes a basis vector by setting all the elements of the vector v to zero except for the i-th element which is set to one.
-    pub fn set_basis(&self, i: usize) -> &VectorF64 {
+    pub fn set_basis(&mut self, i: usize) -> &mut VectorF64 {
         unsafe { ffi::gsl_vector_set_basis(self.vec, i) };
         self
     }
 
     /// This function copies the elements of the other vector into the self vector. The two vectors must have the same length.
-    pub fn copy_from(&self, other: &VectorF64) -> enums::Value {
+    pub fn copy_from(&mut self, other: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_memcpy(self.vec, other.vec) }
     }
 
     /// This function copies the elements of the self vector into the other vector. The two vectors must have the same length.
-    pub fn copy_to(&self, other: &VectorF64) -> enums::Value {
+    pub fn copy_to(&self, other: &mut VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_memcpy(other.vec, self.vec) }
     }
 
     /// This function exchanges the elements of the vectors by copying. The two vectors must have the same length.
-    pub fn swap(&self, other: &VectorF64) -> enums::Value {
+    pub fn swap(&mut self, other: &mut VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_swap(other.vec, self.vec) }
     }
 
     /// This function exchanges the i-th and j-th elements of the vector v in-place.
-    pub fn swap_elements(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_elements(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_vector_swap_elements(self.vec, i, j) }
     }
 
     /// This function reverses the order of the elements of the vector v.
-    pub fn reverse(&self) -> enums::Value {
+    pub fn reverse(&mut self) -> enums::Value {
         unsafe { ffi::gsl_vector_reverse(self.vec) }
     }
 
     /// This function adds the elements of the other vector to the elements of the self vector.
     /// The result a_i <- a_i + b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn add(&self, other: &VectorF64) -> enums::Value {
+    pub fn add(&mut self, other: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_add(self.vec, other.vec) }
     }
 
     /// This function subtracts the elements of the self vector from the elements of the other vector.
     /// The result a_i <- a_i - b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn sub(&self, other: &VectorF64) -> enums::Value {
+    pub fn sub(&mut self, other: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_sub(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector a by the elements of the other vector.
     /// The result a_i <- a_i * b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn mul(&self, other: &VectorF64) -> enums::Value {
+    pub fn mul(&mut self, other: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_mul(self.vec, other.vec) }
     }
 
     /// This function divides the elements of the self vector by the elements of the other vector.
     /// The result a_i <- a_i / b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn div(&self, other: &VectorF64) -> enums::Value {
+    pub fn div(&mut self, other: &VectorF64) -> enums::Value {
         unsafe { ffi::gsl_vector_div(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector by the constant factor x. The result a_i <- a_i is stored in self.
-    pub fn scale(&self, x: f64) -> enums::Value {
+    pub fn scale(&mut self, x: f64) -> enums::Value {
         unsafe { ffi::gsl_vector_scale(self.vec, x) }
     }
 
     /// This function adds the constant value x to the elements of the self vector. The result a_i <- a_i + x is stored in self.
-    pub fn add_constant(&self, x: f64) -> enums::Value {
+    pub fn add_constant(&mut self, x: f64) -> enums::Value {
         unsafe { ffi::gsl_vector_add_constant(self.vec, x) }
     }
 
@@ -679,7 +679,7 @@ impl VectorF64 {
                 None
             } else {
                 match VectorF64::new((*self.vec).size) {
-                    Some(v) => {
+                    Some(mut v) => {
                         v.copy_from(self);
                         Some(v)
                     }

--- a/src/types/vector_complex.rs
+++ b/src/types/vector_complex.rs
@@ -37,7 +37,7 @@ impl VectorComplexF64 {
         if tmp.is_null() {
             None
         } else {
-            let v = VectorComplexF64 {
+            let mut v = VectorComplexF64 {
                 vec: tmp
             };
             let mut pos = 0usize;
@@ -64,85 +64,85 @@ impl VectorComplexF64 {
     }
 
     /// This function sets the value of the i-th element of a vector v to x. If i lies outside the allowed range of 0 to n-1 then the error handler is invoked.
-    pub fn set(&self, i: usize, x: &ComplexF64) -> &VectorComplexF64 {
+    pub fn set(&mut self, i: usize, x: &ComplexF64) -> &VectorComplexF64 {
         unsafe { ffi::gsl_vector_complex_set(self.vec, i, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the vector v to the value x.
-    pub fn set_all(&self, x: &ComplexF64) -> &VectorComplexF64 {
+    pub fn set_all(&mut self, x: &ComplexF64) -> &VectorComplexF64 {
         unsafe { ffi::gsl_vector_complex_set_all(self.vec, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the vector v to zero.
-    pub fn set_zero(&self) -> &VectorComplexF64 {
+    pub fn set_zero(&mut self) -> &VectorComplexF64 {
         unsafe { ffi::gsl_vector_complex_set_zero(self.vec) };
         self
     }
 
     /// This function makes a basis vector by setting all the elements of the vector v to zero except for the i-th element which is set to one.
-    pub fn set_basis(&self, i: usize) -> &VectorComplexF64 {
+    pub fn set_basis(&mut self, i: usize) -> &VectorComplexF64 {
         unsafe { ffi::gsl_vector_complex_set_basis(self.vec, i) };
         self
     }
 
     /// This function copies the elements of the other vector into the self vector. The two vectors must have the same length.
-    pub fn copy_from(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn copy_from(&mut self, other: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_memcpy(self.vec, other.vec) }
     }
 
     /// This function copies the elements of the self vector into the other vector. The two vectors must have the same length.
-    pub fn copy_to(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn copy_to(&self, other: &mut VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_memcpy(other.vec, self.vec) }
     }
 
     /// This function exchanges the elements of the vectors by copying. The two vectors must have the same length.
-    pub fn swap(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn swap(&mut self, other: &mut VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_swap(other.vec, self.vec) }
     }
 
     /// This function exchanges the i-th and j-th elements of the vector v in-place.
-    pub fn swap_elements(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_elements(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_swap_elements(self.vec, i, j) }
     }
 
     /// This function reverses the order of the elements of the vector v.
-    pub fn reverse(&self) -> enums::Value {
+    pub fn reverse(&mut self) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_reverse(self.vec) }
     }
 
     /// This function adds the elements of the other vector to the elements of the self vector.
     /// The result a_i <- a_i + b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn add(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn add(&mut self, other: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_add(self.vec, other.vec) }
     }
 
     /// This function subtracts the elements of the self vector from the elements of the other vector.
     /// The result a_i <- a_i - b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn sub(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn sub(&mut self, other: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_sub(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector a by the elements of the other vector.
     /// The result a_i <- a_i * b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn mul(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn mul(&mut self, other: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_mul(self.vec, other.vec) }
     }
 
     /// This function divides the elements of the self vector by the elements of the other vector.
     /// The result a_i <- a_i / b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn div(&self, other: &VectorComplexF64) -> enums::Value {
+    pub fn div(&mut self, other: &VectorComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_div(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector by the constant factor x. The result a_i <- a_i is stored in self.
-    pub fn scale(&self, x: &ComplexF64) -> enums::Value {
+    pub fn scale(&mut self, x: &ComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_scale(self.vec, ::std::mem::transmute(*x)) }
     }
 
     /// This function adds the constant value x to the elements of the self vector. The result a_i <- a_i + x is stored in self.
-    pub fn add_constant(&self, x: &ComplexF64) -> enums::Value {
+    pub fn add_constant(&mut self, x: &ComplexF64) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_add_constant(self.vec, ::std::mem::transmute(*x)) }
     }
 
@@ -206,7 +206,7 @@ impl VectorComplexF64 {
                 None
             } else {
                 match VectorComplexF64::new((*self.vec).size) {
-                    Some(v) => {
+                    Some(mut v) => {
                         v.copy_from(self);
                         Some(v)
                     }
@@ -286,7 +286,7 @@ impl VectorComplexF32 {
         if tmp.is_null() {
             None
         } else {
-            let v = VectorComplexF32 {
+            let mut v = VectorComplexF32 {
                 vec: tmp
             };
             let mut pos = 0usize;
@@ -313,85 +313,85 @@ impl VectorComplexF32 {
     }
 
     /// This function sets the value of the i-th element of a vector v to x. If i lies outside the allowed range of 0 to n-1 then the error handler is invoked.
-    pub fn set(&self, i: usize, x: &ComplexF32) -> &VectorComplexF32 {
+    pub fn set(&mut self, i: usize, x: &ComplexF32) -> &VectorComplexF32 {
         unsafe { ffi::gsl_vector_complex_float_set(self.vec, i, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the vector v to the value x.
-    pub fn set_all(&self, x: &ComplexF32) -> &VectorComplexF32 {
+    pub fn set_all(&mut self, x: &ComplexF32) -> &VectorComplexF32 {
         unsafe { ffi::gsl_vector_complex_float_set_all(self.vec, ::std::mem::transmute(*x)) };
         self
     }
 
     /// This function sets all the elements of the vector v to zero.
-    pub fn set_zero(&self) -> &VectorComplexF32 {
+    pub fn set_zero(&mut self) -> &VectorComplexF32 {
         unsafe { ffi::gsl_vector_complex_float_set_zero(self.vec) };
         self
     }
 
     /// This function makes a basis vector by setting all the elements of the vector v to zero except for the i-th element which is set to one.
-    pub fn set_basis(&self, i: usize) -> &VectorComplexF32 {
+    pub fn set_basis(&mut self, i: usize) -> &VectorComplexF32 {
         unsafe { ffi::gsl_vector_complex_float_set_basis(self.vec, i) };
         self
     }
 
     /// This function copies the elements of the other vector into the self vector. The two vectors must have the same length.
-    pub fn copy_from(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn copy_from(&mut self, other: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_memcpy(self.vec, other.vec) }
     }
 
     /// This function copies the elements of the self vector into the other vector. The two vectors must have the same length.
-    pub fn copy_to(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn copy_to(&self, other: &mut VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_memcpy(other.vec, self.vec) }
     }
 
     /// This function exchanges the elements of the vectors by copying. The two vectors must have the same length.
-    pub fn swap(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn swap(&mut self, other: &mut VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_swap(other.vec, self.vec) }
     }
 
     /// This function exchanges the i-th and j-th elements of the vector v in-place.
-    pub fn swap_elements(&self, i: usize, j: usize) -> enums::Value {
+    pub fn swap_elements(&mut self, i: usize, j: usize) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_swap_elements(self.vec, i, j) }
     }
 
     /// This function reverses the order of the elements of the vector v.
-    pub fn reverse(&self) -> enums::Value {
+    pub fn reverse(&mut self) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_reverse(self.vec) }
     }
 
     /// This function adds the elements of the other vector to the elements of the self vector.
     /// The result a_i <- a_i + b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn add(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn add(&mut self, other: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_add(self.vec, other.vec) }
     }
 
     /// This function subtracts the elements of the self vector from the elements of the other vector.
     /// The result a_i <- a_i - b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn sub(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn sub(&mut self, other: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_sub(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector a by the elements of the other vector.
     /// The result a_i <- a_i * b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn mul(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn mul(&mut self, other: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_mul(self.vec, other.vec) }
     }
 
     /// This function divides the elements of the self vector by the elements of the other vector.
     /// The result a_i <- a_i / b_i is stored in self and other remains unchanged. The two vectors must have the same length.
-    pub fn div(&self, other: &VectorComplexF32) -> enums::Value {
+    pub fn div(&mut self, other: &VectorComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_div(self.vec, other.vec) }
     }
 
     /// This function multiplies the elements of the self vector by the constant factor x. The result a_i <- a_i is stored in self.
-    pub fn scale(&self, x: &ComplexF32) -> enums::Value {
+    pub fn scale(&mut self, x: &ComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_scale(self.vec, ::std::mem::transmute(*x)) }
     }
 
     /// This function adds the constant value x to the elements of the self vector. The result a_i <- a_i + x is stored in self.
-    pub fn add_constant(&self, x: &ComplexF32) -> enums::Value {
+    pub fn add_constant(&mut self, x: &ComplexF32) -> enums::Value {
         unsafe { ffi::gsl_vector_complex_float_add_constant(self.vec, ::std::mem::transmute(*x)) }
     }
 
@@ -456,7 +456,7 @@ impl VectorComplexF32 {
                 None
             } else {
                 match VectorComplexF32::new((*self.vec).size) {
-                    Some(v) => {
+                    Some(mut v) => {
                         v.copy_from(self);
                         Some(v)
                     }


### PR DESCRIPTION
this fixes #7 partially. For all the vector and matrix types, forces mutability at the ffi boundaries; 

It also forces mutability for the Rng type for some methods, as it usually means a change in the internal state of the generator (this is how is done for the rand crate, for example) and I think is good to keep it like that.