### PR TITLE
Update build bin to panic when probing fails

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,14 +7,11 @@ fn main() {
         return;
     }
 
-    match pkg_config::probe_library("gsl") {
-        Ok(lib) => {
+    pkg_config::probe_library("gsl")
+        .map(|lib| {
             if lib.version.starts_with("2.") {
                 println!(r#"cargo:rustc-cfg=feature="v2""#);
             }
-        }
-        Err(e) => {
-            println!("GSL library not found: {:?}", e);
-        }
-    }
+        })
+        .expect("GSL library not found");
 }


### PR DESCRIPTION
I've discovered a minor bug with the build system that resurfaces when `pkg-config` is present on the OS, however, `gsl` package is not installed, and hence, not detected by `pkg-config`. In the current version of the `build.rs` script, the error message is written to an output file rather than to the console (unless, of course, you invoke cargo as 'very verbose', with `-vv` flag), and the compilation of the library goes through without a problem:

```rust
match pkg_config::probe_library("gsl") {
    Ok(lib) => { ... },
    Err(e) => {
        println!("GSL library not found: {:?}", e);
    }
}
```

I reckon it would be more informative to panic, and print out the message immediately to the console:

```rust
pkg_config::probe_library("gsl")
    .map(|lib| { ... })
    .expect("GSL library not found");
```