### PR TITLE
Use updated SPDX Identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/GuillaumeGomez/rust-GSL"
 documentation = "https://docs.rs/crate/GSL/"
 readme = "README.md"
 keywords = ["mathematics", "library", "GSL"]
-license = "GPL-3.0+"
+license = "GPL-3.0-or-later"
 
 build = "build.rs"
 


### PR DESCRIPTION
"GPL-3.0+" has been deprecated in favor of "GPL-3.0-or-later"