### PR TITLE
remove bug causing - unnessesary alias

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -147,7 +147,6 @@ pub fn min(data: &[f64], stride: usize) -> f64 {
 }
 
 /// Returns `(min, max)`.
-#[doc(alias = "gsl_stats_minmax")]
 pub fn gsl_stats_minmax(data: &[f64], stride: usize) -> (f64, f64) {
     let mut min = 0.;
     let mut max = 0.;
@@ -167,7 +166,6 @@ pub fn min_index(data: &[f64], stride: usize) -> usize {
 }
 
 /// Returns `(min, max)`.
-#[doc(alias = "gsl_stats_minmax_index")]
 pub fn gsl_stats_minmax_index(data: &[f64], stride: usize) -> (usize, usize) {
     let mut min = 0;
     let mut max = 0;


### PR DESCRIPTION
I removed the aliases, which were the same as the function name, because they prevented compiling under Rust 1.51 and above.