### PR TITLE
Multiple fixes/improvements and upgrade crate version to 4.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
+      - run: cargo clippy -- -D warnings
       - run: cargo check
       - run: cargo check --features v2_1
       - run: cargo check --features v2_2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "GSL"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 description = "A rust binding for the GSL (the GNU scientific library)"
 repository = "https://github.com/GuillaumeGomez/rust-GSL"

--- a/gsl-sys/Cargo.toml
+++ b/gsl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "GSL-sys"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "A rust binding for the GSL (the GNU scientific library)"

--- a/gsl-sys/src/lib.rs
+++ b/gsl-sys/src/lib.rs
@@ -7,6 +7,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(clippy::redundant_static_lifetimes)]
+#![allow(clippy::upper_case_acronyms)]
 
 pub extern crate libc;
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -11,7 +11,7 @@ pub enum Mode {
     PrecApprox,
 }
 
-#[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_mode_t> for Mode {
     fn into(self) -> sys::gsl_mode_t {
         match self {
@@ -103,6 +103,7 @@ pub enum Value {
     /// cannot reach the specified tolerance in gradient
     ToleranceG,
     /// cannot reach the specified tolerance in gradient
+    #[allow(clippy::upper_case_acronyms)]
     EOF,
     /// Unknown value.
     Unknown(i32),
@@ -115,6 +116,7 @@ impl Value {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<c_int> for Value {
     fn into(self) -> c_int {
         match self {
@@ -215,6 +217,7 @@ pub enum EigenSort {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_eigen_sort_t> for EigenSort {
     fn into(self) -> sys::gsl_eigen_sort_t {
         match self {
@@ -253,6 +256,7 @@ pub enum FftDirection {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_fft_direction> for FftDirection {
     fn into(self) -> sys::gsl_fft_direction {
         match self {
@@ -292,6 +296,7 @@ pub enum GaussKronrodRule {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<::std::os::raw::c_int> for GaussKronrodRule {
     fn into(self) -> ::std::os::raw::c_int {
         let x = match self {
@@ -329,6 +334,7 @@ pub enum IntegrationQawo {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_integration_qawo_enum> for IntegrationQawo {
     fn into(self) -> sys::gsl_integration_qawo_enum {
         match self {
@@ -364,6 +370,7 @@ pub enum VegasMode {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<::std::os::raw::c_int> for VegasMode {
     fn into(self) -> ::std::os::raw::c_int {
         match self {
@@ -398,6 +405,7 @@ pub enum ODEiv {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<c_int> for ODEiv {
     fn into(self) -> c_int {
         match self {
@@ -427,6 +435,7 @@ pub enum WaveletDirection {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_wavelet_direction> for WaveletDirection {
     fn into(self) -> sys::gsl_wavelet_direction {
         match self {
@@ -456,6 +465,7 @@ pub enum SfLegendreNorm {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::gsl_sf_legendre_t> for SfLegendreNorm {
     fn into(self) -> sys::gsl_sf_legendre_t {
         match self {
@@ -488,6 +498,7 @@ pub enum CblasTranspose {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::CBLAS_TRANSPOSE> for CblasTranspose {
     fn into(self) -> sys::CBLAS_TRANSPOSE {
         match self {
@@ -517,6 +528,7 @@ pub enum CblasUplo {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::CBLAS_UPLO> for CblasUplo {
     fn into(self) -> sys::CBLAS_UPLO {
         match self {
@@ -544,6 +556,7 @@ pub enum CblasOrder {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::CBLAS_ORDER> for CblasOrder {
     fn into(self) -> sys::CBLAS_ORDER {
         match self {
@@ -571,6 +584,7 @@ pub enum CblasSide {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::CBLAS_SIDE> for CblasSide {
     fn into(self) -> sys::CBLAS_SIDE {
         match self {
@@ -598,6 +612,7 @@ pub enum CblasDiag {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 impl Into<sys::CBLAS_SIDE> for CblasDiag {
     fn into(self) -> sys::CBLAS_SIDE {
         match self {
@@ -628,6 +643,7 @@ pub enum FilterEnd {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 #[cfg(feature = "v2_5")]
 impl Into<sys::gsl_filter_end_t> for FilterEnd {
     fn into(self) -> sys::gsl_filter_end_t {
@@ -663,6 +679,7 @@ pub enum FilterScale {
 }
 
 #[doc(hidden)]
+#[allow(clippy::from_over_into)]
 #[cfg(feature = "v2_5")]
 impl Into<sys::gsl_filter_scale_t> for FilterScale {
     fn into(self) -> sys::gsl_filter_scale_t {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -394,6 +394,7 @@ impl From<::std::os::raw::c_int> for VegasMode {
 }
 
 /// Possible return values for an hadjust() evolution method for ordinary differential equations
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
 pub enum ODEiv {
     /// step was increased

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,6 +2,7 @@
 // A rust binding for the GSL library by Guillaume Gomez (guillaume1.gomez@gmail.com)
 //
 
+#[allow(clippy::upper_case_acronyms)]
 pub trait FFI<T> {
     fn wrap(r: *mut T) -> Self;
     fn soft_wrap(r: *mut T) -> Self;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -148,7 +148,7 @@ pub fn min(data: &[f64], stride: usize) -> f64 {
 
 /// Returns `(min, max)`.
 #[doc(alias = "gsl_stats_minmax")]
-pub fn gsl_stats_minmax(data: &[f64], stride: usize) -> (f64, f64) {
+pub fn stats_minmax(data: &[f64], stride: usize) -> (f64, f64) {
     let mut min = 0.;
     let mut max = 0.;
 
@@ -168,7 +168,7 @@ pub fn min_index(data: &[f64], stride: usize) -> usize {
 
 /// Returns `(min, max)`.
 #[doc(alias = "gsl_stats_minmax_index")]
-pub fn gsl_stats_minmax_index(data: &[f64], stride: usize) -> (usize, usize) {
+pub fn stats_minmax_index(data: &[f64], stride: usize) -> (usize, usize) {
     let mut min = 0;
     let mut max = 0;
 

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -9,12 +9,14 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 #[doc(hidden)]
+#[allow(clippy::upper_case_acronyms)]
 pub trait CFFI<T> {
     fn wrap(s: T) -> Self;
     fn unwrap(self) -> T;
 }
 
 #[doc(hidden)]
+#[allow(clippy::upper_case_acronyms)]
 pub trait FFFI<T> {
     fn wrap(self) -> T;
     fn unwrap(t: T) -> Self;

--- a/src/types/integration.rs
+++ b/src/types/integration.rs
@@ -2,6 +2,8 @@
 // A rust binding for the GSL library by Guillaume Gomez (guillaume1.gomez@gmail.com)
 //
 
+#![allow(clippy::upper_case_acronyms)]
+
 use crate::enums;
 use crate::Value;
 use ffi::FFI;

--- a/src/types/ordinary_differential_equations.rs
+++ b/src/types/ordinary_differential_equations.rs
@@ -59,6 +59,8 @@ A. C. Hindmarsh, P. N. Brown, K. E. Grant, S. L. Lee, R. Serban, D. E. Shumaker 
 Differential/Algebraic Equation Solvers.”, ACM Trans. Math. Software 31, 363–396, 2005.
 !*/
 
+#![allow(clippy::upper_case_acronyms)]
+
 use crate::Value;
 use ffi::FFI;
 use std::os::raw::{c_int, c_void};

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -130,6 +130,10 @@ impl $rust_name {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn as_slice(&self) -> Option<&[$rust_ty]> {
         let ptr = unsafe { (*self.unwrap_shared()).data };
         if ptr.is_null() {

--- a/src/types/vector_complex.rs
+++ b/src/types/vector_complex.rs
@@ -103,6 +103,10 @@ macro_rules! gsl_vec_complex {
                 }
             }
 
+            pub fn is_empty(&self) -> bool {
+                self.len() == 0
+            }
+
             pub fn as_slice(&self) -> Option<&[$rust_ty]> {
                 let ptr = unsafe { (*self.unwrap_shared()).data };
                 if ptr.is_null() {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -15,6 +15,7 @@ enum Mode {
 }
 
 /// A wrapper to handle I/O operations between GSL and rust
+#[allow(clippy::upper_case_acronyms)]
 pub struct IOStream {
     inner: *mut FILE,
     mode: Mode,


### PR DESCRIPTION
Fixes #95.

This also does the following:
 * Fix some stats functions names
 * Implement `is_empty` on the vector types
 * Fix clippy lints
 * Enforce clippy checks on the CI
 * Upgrade GSL version to 4.0.0
 * Upgrade GSL-sys version to 2.0.2