### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/types/discrete_hankel.rs
+++ b/src/types/discrete_hankel.rs
@@ -97,19 +97,19 @@ impl DiscreteHankel {
     /// up to numerical errors.
     #[doc(alias = "gsl_dht_apply")]
     pub fn apply(&mut self, f_in: &[f64]) -> (Value, Vec<f64>) {
-        unsafe {
+        
             assert!(
-                (*self.unwrap_shared()).size == f_in.len() as _,
+                unsafe { (*self.unwrap_shared()).size == f_in.len() as _ },
                 "f_in and f_out must have the same length as this struct"
             );
             let mut f_out: Vec<f64> = ::std::iter::repeat(0.).take(f_in.len()).collect();
-            let ret = sys::gsl_dht_apply(
+            let ret = unsafe { sys::gsl_dht_apply(
                 self.unwrap_unique(),
                 f_in.as_ptr() as usize as *mut _,
                 f_out.as_mut_ptr(),
-            );
+            ) };
             (Value::from(ret), f_out)
-        }
+        
     }
 
     /// This function returns the value of the n-th sample point in the unit interval,

--- a/src/types/rng.rs
+++ b/src/types/rng.rs
@@ -898,18 +898,18 @@ impl RngType {
         let mut ret = Vec::new();
 
         if !ptr.is_null() {
-            unsafe {
+            
                 let mut it = 0;
                 loop {
-                    let tmp = ptr.offset(it);
+                    let tmp = unsafe { ptr.offset(it) };
 
-                    if (*tmp).is_null() {
+                    if unsafe { (*tmp).is_null() } {
                         break;
                     }
-                    ret.push(RngType::wrap(*tmp as *mut sys::gsl_rng_type));
+                    unsafe { ret.push(RngType::wrap(*tmp as *mut sys::gsl_rng_type)) };
                     it += 1;
                 }
-            }
+            
         }
         ret
     }

--- a/src/types/roots.rs
+++ b/src/types/roots.rs
@@ -327,21 +327,21 @@ impl<'a> RootFdfSolver<'a> {
     /// Returns the solver type name.
     #[doc(alias = "gsl_root_fdfsolver_name")]
     pub fn name(&self) -> Option<&str> {
-        unsafe {
-            let ptr = sys::gsl_root_fdfsolver_name(self.unwrap_shared());
+        
+            let ptr = unsafe { sys::gsl_root_fdfsolver_name(self.unwrap_shared()) };
 
             if ptr.is_null() {
                 return None;
             }
 
             let mut len = 0;
-            while *ptr.add(len) != 0 {
+            while unsafe { *ptr.add(len) != 0 } {
                 len += 1;
             }
 
-            let slice = ::std::slice::from_raw_parts(ptr as *const _, len);
+            let slice = unsafe { ::std::slice::from_raw_parts(ptr as *const _, len) };
             ::std::str::from_utf8(slice).ok()
-        }
+        
     }
 
     /// This function returns the current estimate of the root for the solver s.

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -55,7 +55,7 @@ impl Drop for IOStream {
     fn drop(&mut self) {
         unsafe {
             fclose(self.inner);
-            self.inner = ::std::ptr::null_mut();
         }
+        self.inner = ::std::ptr::null_mut();
     }
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html