### PR TITLE
Mark bernoulli_pdf function as unsafe

### DIFF
--- a/src/randist/bernoulli.rs
+++ b/src/randist/bernoulli.rs
@@ -4,6 +4,6 @@
 
 /// This function computes the probability p(k) of obtaining k from a Bernoulli distribution with probability parameter p, using the formula given above.
 #[doc(alias = "gsl_ran_bernoulli_pdf")]
-pub fn bernoulli_pdf(x: u32, p: f64) -> f64 {
-    unsafe { sys::gsl_ran_bernoulli_pdf(x, p) }
+pub unsafe fn bernoulli_pdf(x: u32, p: f64) -> f64 {
+    sys::gsl_ran_bernoulli_pdf(x, p)
 }


### PR DESCRIPTION
https://github.com/GuillaumeGomez/rust-GSL/blob/234cfc26deef8b096e5e8c6a34e0463f5e89bc74/src/randist/bernoulli.rs#L7-L9
Hello, it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the bernoulli_pdf function may not notice this safety requirement.

Marking them unsafe also means that callers must make sure they know what they're doing.