### PR TITLE
Make safe the functions of the "fit" module

### DIFF
--- a/src/dawson.rs
+++ b/src/dawson.rs
@@ -7,7 +7,7 @@ The Dawson integral is defined by \exp(-x^2) \int_0^x dt \exp(t^2).
 A table of Dawson’s integral can be found in Abramowitz & Stegun, Table 7.5.
 !*/
 
-use crate::{sys, types, Value};
+use crate::{types, Value};
 use std::mem::MaybeUninit;
 
 /// This routine computes the value of Dawson’s integral for x.

--- a/src/dilogarithm.rs
+++ b/src/dilogarithm.rs
@@ -2,7 +2,7 @@
 // A rust binding for the GSL library by Guillaume Gomez (guillaume1.gomez@gmail.com)
 //
 
-use crate::{sys, types, Value};
+use crate::{types, Value};
 use std::mem::MaybeUninit;
 
 /// These routines compute the dilogarithm for a real argument. In Lewin’s notation this is Li_2(x), the real part of the dilogarithm of a real x.

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -32,6 +32,9 @@ pub fn linear(
     ystride: usize,
     n: usize,
 ) -> Result<(f64, f64, f64, f64, f64, f64), Value> {
+    if (n - 1) * xstride >= x.len() || (n - 1) * ystride >= y.len() {
+        return Err(Value::Invalid);
+    }
     let mut c0 = 0.;
     let mut c1 = 0.;
     let mut cov00 = 0.;
@@ -79,6 +82,10 @@ pub fn wlinear(
     ystride: usize,
     n: usize,
 ) -> Result<(f64, f64, f64, f64, f64, f64), Value> {
+    if (n - 1) * xstride >= x.len() || (n - 1) * wstride >= w.len() || (n - 1) * ystride >= y.len()
+    {
+        return Err(Value::Invalid);
+    }
     let mut c0 = 0.;
     let mut c1 = 0.;
     let mut cov00 = 0.;
@@ -141,6 +148,9 @@ pub fn mul(
     ystride: usize,
     n: usize,
 ) -> Result<(f64, f64, f64), Value> {
+    if (n - 1) * xstride >= x.len() || (n - 1) * ystride >= y.len() {
+        return Err(Value::Invalid);
+    }
     let mut c1 = 0.;
     let mut cov11 = 0.;
     let mut sumsq = 0.;
@@ -170,6 +180,10 @@ pub fn wmul(
     ystride: usize,
     n: usize,
 ) -> Result<(f64, f64, f64), Value> {
+    if (n - 1) * xstride >= x.len() || (n - 1) * wstride >= w.len() || (n - 1) * ystride >= y.len()
+    {
+        return Err(Value::Invalid);
+    }
     let mut c1 = 0.;
     let mut cov11 = 0.;
     let mut sumsq = 0.;

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -4,7 +4,6 @@
 
 // TODO : port to Rust type : http://doc.rust-lang.org/num/complex/struct.Complex.html
 
-use std::default::Default;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 

--- a/src/types/minimizer.rs
+++ b/src/types/minimizer.rs
@@ -98,7 +98,6 @@ provided the function is well-behaved.
 
 use crate::Value;
 use ffi::FFI;
-use sys;
 
 ffi_wrapper!(
     Minimizer<'a>,

--- a/src/types/multiroot.rs
+++ b/src/types/multiroot.rs
@@ -58,7 +58,6 @@ The algorithms estimate the matrix J or J^{-1} by approximate methods.
 
 use crate::{Value, VectorF64, View};
 use ffi::FFI;
-use sys;
 use sys::libc::{c_int, c_void};
 
 ffi_wrapper!(

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -2,8 +2,6 @@
 // A rust binding for the GSL library by Guillaume Gomez (guillaume1.gomez@gmail.com)
 //
 
-use std::default::Default;
-
 /// The error handling form of the special functions always calculate an error estimate along with the value of the result.
 /// Therefore, structures are provided for amalgamating a value and error estimate.
 #[derive(Clone, Copy, Debug)]

--- a/src/types/roots.rs
+++ b/src/types/roots.rs
@@ -43,7 +43,6 @@ its derivative (hence the name fdf) to be supplied by the user.
 
 use crate::Value;
 use ffi::FFI;
-use sys;
 use sys::libc::{c_double, c_void};
 
 ffi_wrapper!(

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -4,7 +4,6 @@
 
 use std::ffi::CString;
 use std::io;
-use std::ops::Drop;
 use std::os::raw::c_char;
 use std::path::Path;
 


### PR DESCRIPTION
The functions `fit::linear`,... were not checking that the length `n` was not too large (in which case the function would access memory outside the slice 😨).  This PR fixes that.

P.S. IMHO, the strides and length parameters should be optional.  For example a trait for “slice or (slice, stride)” would be simple and convenient (for strides, not the length `n`).  For a better “Rust like” user experience, bigger changes are needed (I can try to propose something if you agree that such a change is beneficial).