### PR TITLE
Adding minimization with derivatives to multimin

### DIFF
--- a/gsl-sys/src/auto.rs
+++ b/gsl-sys/src/auto.rs
@@ -21931,10 +21931,19 @@ pub struct gsl_multimin_function_fdf_struct {
         unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void) -> f64,
     >,
     pub df: ::std::option::Option<
-        unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void, g: *mut gsl_vector) -> (),
+        unsafe extern "C" fn(
+            x: *const gsl_vector,
+            params: *mut ::std::os::raw::c_void,
+            g: *mut gsl_vector,
+        ) -> (),
     >,
     pub fdf: ::std::option::Option<
-        unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void, f: *mut f64,g: *mut gsl_vector) -> (),
+        unsafe extern "C" fn(
+            x: *const gsl_vector,
+            params: *mut ::std::os::raw::c_void,
+            f: *mut f64,
+            g: *mut gsl_vector,
+        ) -> (),
     >,
     pub n: usize,
     pub params: *mut ::std::os::raw::c_void,

--- a/gsl-sys/src/auto.rs
+++ b/gsl-sys/src/auto.rs
@@ -21926,8 +21926,21 @@ pub struct gsl_multimin_function_struct {
 pub type gsl_multimin_function = gsl_multimin_function_struct;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct gsl_multimin_function_fdf_struct;
+pub struct gsl_multimin_function_fdf_struct {
+    pub f: ::std::option::Option<
+        unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void) -> f64,
+    >,
+    pub df: ::std::option::Option<
+        unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void, g: *mut gsl_vector) -> (),
+    >,
+    pub fdf: ::std::option::Option<
+        unsafe extern "C" fn(x: *const gsl_vector, params: *mut ::std::os::raw::c_void, f: *mut f64,g: *mut gsl_vector) -> (),
+    >,
+    pub n: usize,
+    pub params: *mut ::std::os::raw::c_void,
+}
 pub type gsl_multimin_function_fdf = gsl_multimin_function_fdf_struct;
+
 extern "C" {
     pub fn gsl_multimin_diff(
         f: *const gsl_multimin_function,

--- a/src/multimin.rs
+++ b/src/multimin.rs
@@ -2,12 +2,21 @@
 // A rust binding for the GSL library by Guillaume Gomez (guillaume1.gomez@gmail.com)
 //
 
+use crate::ffi::FFI;
 use crate::Value;
 
 /// This function tests the minimizer specific characteristic size (if applicable to the used minimizer) against absolute tolerance `epsabs`.
 /// The test returns `crate::Value::Success` if the size is smaller than tolerance, otherwise crate::Value::Continue is returned.
-
 #[doc(alias = "gsl_multimin_test_size")]
 pub fn test_size(size: f64, epsabs: f64) -> Value {
     Value::from(unsafe { sys::gsl_multimin_test_size(size, epsabs) })
+}
+
+/// This function tests the norm of the gradient `g` against the absolute tolerance `epsabs`.
+/// The gradient of a multidimensional function goes to zero at a minimum. The test returns `crate::Value::Success` if the following condition is achieved, |g| < epsabs
+/// and returns `crate::Value::Continue` otherwise. A suitable choice of `epsabs` can be made from the desired accuracy in the function for small variations in `x`.
+/// The relationship between these quantities is given by \delta{f} = g\,\delta{x}.
+#[doc(alias = "gsl_multimin_test_gradient")]
+pub fn test_gradient(g: &crate::VectorF64, epsabs: f64) -> Value {
+    Value::from(unsafe { sys::gsl_multimin_test_gradient(g.unwrap_shared(), epsabs) })
 }

--- a/src/types/multimin.rs
+++ b/src/types/multimin.rs
@@ -81,7 +81,7 @@ ffi_wrapper!(
 impl<'a> Minimizer<'a> {
     /// Creates a minimizer of type `t` for an n-dimensional function.
     /// If there is insufficient memory to create the minimizer then
-    /// the function returns a null pointer and the error handler is invoked with an error code of `Value::NoMemory`.
+    /// the function returns `None`.
     #[doc(alias = "gsl_multimin_fminimizer_alloc")]
     pub fn new(t: MinimizerType, n: usize) -> Option<Minimizer<'a>> {
         let ptr = unsafe { sys::gsl_multimin_fminimizer_alloc(t.unwrap_shared(), n) };
@@ -93,7 +93,7 @@ impl<'a> Minimizer<'a> {
         }
     }
 
-    /// This function initializes the minimizer `s` to minimize the function `f`, starting from the initial point `x`.
+    /// This function initializes the minimizer to minimize the function `f`, starting from the initial point `x`.
     /// The size of the initial trial steps is given in vector `step_size`. The precise meaning of this
     /// parameter depends on the method used.
     #[doc(alias = "gsl_multimin_fminimizer_set")]
@@ -193,6 +193,221 @@ impl MinimizerType {
     }
 }
 
+pub struct MultiMinFdfFunction<'a> {
+    pub f: Box<dyn Fn(&VectorF64) -> f64 + 'a>,
+    pub df: Box<dyn Fn(&VectorF64, &mut VectorF64) + 'a>,
+    pub fdf: Box<dyn Fn(&VectorF64, &mut VectorF64) -> f64 + 'a>,
+    pub n: usize,
+    intern: sys::gsl_multimin_function_fdf,
+}
+
+impl<'a> MultiMinFdfFunction<'a> {
+    #[doc(alias = "gsl_multimin_function_fdf")]
+    pub fn new<
+        F: Fn(&VectorF64) -> f64 + 'a,
+        DF: Fn(&VectorF64, &mut VectorF64) + 'a,
+        FDF: Fn(&VectorF64, &mut VectorF64) -> f64 + 'a,
+    >(
+        f: F,
+        df: DF,
+        fdf: FDF,
+        n: usize,
+    ) -> MultiMinFdfFunction<'a> {
+        unsafe extern "C" fn inner_f(x: *const sys::gsl_vector, params: *mut c_void) -> f64 {
+            let t = &*(params as *mut MultiMinFdfFunction);
+            let i_f = &t.f;
+            i_f(&VectorF64::soft_wrap(x as *const _ as *mut _))
+        }
+
+        unsafe extern "C" fn inner_df(
+            x: *const sys::gsl_vector,
+            params: *mut c_void,
+            g: *mut sys::gsl_vector,
+        ) {
+            let t = &*(params as *mut MultiMinFdfFunction);
+            let i_df = &t.df;
+            i_df(
+                &VectorF64::soft_wrap(x as *const _ as *mut _),
+                &mut VectorF64::soft_wrap(g as *const _ as *mut _),
+            );
+        }
+
+        unsafe extern "C" fn inner_fdf(
+            x: *const sys::gsl_vector,
+            params: *mut c_void,
+            f: *mut f64,
+            g: *mut sys::gsl_vector,
+        ) {
+            let t = &*(params as *mut MultiMinFdfFunction);
+            let i_fdf = &t.fdf;
+            *f = i_fdf(
+                &VectorF64::soft_wrap(x as *const _ as *mut _),
+                &mut VectorF64::soft_wrap(g as *const _ as *mut _),
+            );
+        }
+
+        MultiMinFdfFunction {
+            f: Box::new(f),
+            df: Box::new(df),
+            fdf: Box::new(fdf),
+            n,
+            intern: sys::gsl_multimin_function_fdf {
+                f: Some(inner_f),
+                df: Some(inner_df),
+                fdf: Some(inner_fdf),
+                n,
+                params: std::ptr::null_mut(),
+            },
+        }
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+
+    fn to_raw(&mut self) -> *mut sys::gsl_multimin_function_fdf {
+        self.intern.n = self.n;
+        self.intern.params = self as *mut MultiMinFdfFunction as *mut c_void;
+        &mut self.intern
+    }
+}
+
+ffi_wrapper!(
+    MinimizerFdf,
+    *mut sys::gsl_multimin_fdfminimizer,
+    gsl_multimin_fdfminimizer_free
+);
+
+impl MinimizerFdf {
+    /// Creates a minimizer of type `t` for an n-dimensional function.
+    /// If there is insufficient memory to create the minimizer then
+    /// the function returns a `None`.
+    #[doc(alias = "gsl_multimin_fminimizer_alloc")]
+    pub fn new(t: MinimizerFdfType, n: usize) -> Option<MinimizerFdf> {
+        let ptr = unsafe { sys::gsl_multimin_fdfminimizer_alloc(t.unwrap_shared(), n) };
+
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self::wrap(ptr))
+        }
+    }
+
+    /// This function initializes the minimizer to minimize the function `fdf` starting from the initial point `x`.
+    /// The size of the first trial step is given by `step_size`. The accuracy of the line minimization is specified by `tol`.
+    /// The precise meaning of this parameter depends on the method used. Typically the line minimization is considered successful if the gradient of the function `g` is orthogonal
+    /// to the current search direction `p` to a relative accuracy of `tol`, where p . g < tol |p| |g|. A `tol` value of 0.1 is suitable for most purposes,
+    /// since line minimization only needs to be carried out approximately. Note that setting tol to zero will force the use of “exact” line-searches, which are extremely expensive.
+    #[doc(alias = "gsl_multimin_fdfminimizer_set")]
+    pub fn set(
+        &mut self,
+        f: &mut MultiMinFdfFunction,
+        x: &VectorF64,
+        step_size: f64,
+        tol: f64,
+    ) -> Result<(), Value> {
+        let ret = unsafe {
+            sys::gsl_multimin_fdfminimizer_set(
+                self.unwrap_unique(),
+                f.to_raw(),
+                x.unwrap_shared(),
+                step_size,
+                tol,
+            )
+        };
+        result_handler!(ret, ())
+    }
+
+    /// This function returns a pointer to the name of the minimizer.
+    #[doc(alias = "gsl_multimin_fdfminimizer_name")]
+    pub fn name(&self) -> Option<String> {
+        let n = unsafe { sys::gsl_multimin_fdfminimizer_name(self.unwrap_shared()) };
+        if n.is_null() {
+            return None;
+        }
+        let mut len = 0;
+        loop {
+            if unsafe { *n.offset(len) } == 0 {
+                break;
+            }
+            len += 1;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(n as _, len as _) };
+        std::str::from_utf8(slice).ok().map(|x| x.to_owned())
+    }
+
+    /// Returns the current best estimate of the location of the minimum.
+    #[doc(alias = "gsl_multimin_fdfminimizer_x")]
+    pub fn x(&self) -> VectorF64 {
+        unsafe { VectorF64::soft_wrap(sys::gsl_multimin_fdfminimizer_x(self.unwrap_shared())) }
+    }
+
+    /// Returns the value of the function at the minimum.
+    #[doc(alias = "gsl_multimin_fdfminimizer_minimum")]
+    pub fn minimum(&self) -> f64 {
+        unsafe { sys::gsl_multimin_fdfminimizer_minimum(self.unwrap_shared()) }
+    }
+
+    /// Returns the gradient of the function at the minimum.
+    #[doc(alias = "gsl_multimin_fdfminimizer_gradient")]
+    pub fn gradient(&self) -> VectorF64 {
+        unsafe {
+            VectorF64::soft_wrap(sys::gsl_multimin_fdfminimizer_gradient(
+                self.unwrap_shared(),
+            ))
+        }
+    }
+
+    /// Returns the last step increment of the estimate.
+    #[doc(alias = "gsl_multimin_fdfminimizer_dx")]
+    pub fn dx(&self) -> VectorF64 {
+        unsafe { VectorF64::soft_wrap(sys::gsl_multimin_fdfminimizer_dx(self.unwrap_shared())) }
+    }
+
+    /// This function performs a single iteration of the minimizer s. If the iteration encounters
+    /// an unexpected problem then an error code will be returned. The error code `Value::NoProgress`
+    /// signifies that the minimizer is unable to improve on its current estimate, either due
+    /// to numerical difficulty or because a genuine local minimum has been reached.
+    #[doc(alias = "gsl_multimin_fdfminimizer_iterate")]
+    pub fn iterate(&mut self) -> Result<(), Value> {
+        let ret = unsafe { sys::gsl_multimin_fdfminimizer_iterate(self.unwrap_unique()) };
+        result_handler!(ret, ())
+    }
+
+    /// This function resets the minimizer to use the current point as a new starting point.
+    #[doc(alias = "gsl_multimin_fdfminimizer_restart")]
+    pub fn restart(&mut self) -> i32 {
+        unsafe { sys::gsl_multimin_fdfminimizer_restart(self.unwrap_unique()) }
+    }
+}
+
+ffi_wrapper!(MinimizerFdfType, *const sys::gsl_multimin_fdfminimizer_type);
+
+impl MinimizerFdfType {
+    #[doc(alias = "gsl_multimin_fdfminimizer_conjugate_fr")]
+    pub fn conjugate_fr() -> Self {
+        ffi_wrap!(gsl_multimin_fdfminimizer_conjugate_fr)
+    }
+
+    #[doc(alias = "gsl_multimin_fdfminimizer_conjugate_pr")]
+    pub fn conjugate_pr() -> Self {
+        ffi_wrap!(gsl_multimin_fdfminimizer_conjugate_pr)
+    }
+
+    #[doc(alias = "gsl_multimin_fdfminimizer_vector_bfgs")]
+    pub fn vector_bfgs() -> Self {
+        ffi_wrap!(gsl_multimin_fdfminimizer_vector_bfgs)
+    }
+
+    #[doc(alias = "gsl_multimin_fdfminimizer_vector_bfgs2")]
+    pub fn vector_bfgs2() -> Self {
+        ffi_wrap!(gsl_multimin_fdfminimizer_vector_bfgs2)
+    }
+
+    #[doc(alias = "gsl_multimin_fdfminimizer_steepest_descent")]
+    pub fn steepest_descent() -> Self {
+        ffi_wrap!(gsl_multimin_fdfminimizer_steepest_descent)
+    }
+}
+
 #[cfg(any(test, doctest))]
 mod test {
     /// This doc block will be used to ensure that the closure can't be set everywhere!
@@ -212,6 +427,7 @@ mod test {
     ///     let mut mint = Minimizer::new(MinimizerType::nm_simplex(), 2).unwrap();
     ///     set(&mut mint);
     ///     let _status = mint.iterate();
+    /// }
     /// ```
     ///
     /// Same but a working version:
@@ -232,9 +448,10 @@ mod test {
     /// }
     /// ```
     use super::*;
+    use crate::multimin::test_gradient;
     use crate::multimin::test_size;
 
-    fn print_state(min: &Minimizer, iter: usize) {
+    fn print_f_state(min: &Minimizer, iter: usize) {
         let f = min.minimum();
         let x = min.x();
         println!(
@@ -246,23 +463,35 @@ mod test {
         )
     }
 
+    fn print_fdf_state(min: &MinimizerFdf, iter: usize) {
+        let f = min.minimum();
+        let x = min.x();
+        println!(
+            "iter: {}, f = {:+.2e}, x = [{:+.5}, {:+.5}]",
+            iter,
+            f,
+            x.get(0),
+            x.get(1),
+        )
+    }
+
+    const CENTER: (f64, f64) = (1.0, 2.0);
+    const SCALE: (f64, f64) = (10.0, 20.0);
+    const MINIMUM: f64 = 30.0;
+
+    fn paraboloid(v: &VectorF64) -> f64 {
+        let x = v.get(0);
+        let y = v.get(1);
+        let result =
+            SCALE.0 * (x - CENTER.0).powf(2.0) + SCALE.1 * (y - CENTER.1).powf(2.0) + MINIMUM;
+        result
+    }
+
     #[test]
     fn test_multi_min() {
         let mut min = Minimizer::new(MinimizerType::nm_simplex2(), 2).unwrap();
         let guess_value = VectorF64::from_slice(&[5.0, 7.0]).unwrap();
         let step_size = VectorF64::from_slice(&[1.0, 1.0]).unwrap();
-
-        let paraboloid = |v: &VectorF64| -> f64 {
-            let center = (1.0, 2.0);
-            let scale = (10.0, 20.0);
-            let minimum = 30.0;
-
-            let x = v.get(0);
-            let y = v.get(1);
-            let result =
-                scale.0 * (x - center.0).powf(2.0) + scale.1 * (y - center.1).powf(2.0) + minimum;
-            result
-        };
 
         min.set(paraboloid, &guess_value, &step_size).unwrap();
 
@@ -287,7 +516,54 @@ mod test {
             }
 
             // print current iteration
-            print_state(&min, iter);
+            print_f_state(&min, iter);
+
+            iter += 1;
+        }
+    }
+
+    #[test]
+    fn test_multi_fdf_min() {
+        let mut min = MinimizerFdf::new(MinimizerFdfType::conjugate_fr(), 2).unwrap();
+        let guess_value = VectorF64::from_slice(&[5.0, 7.0]).unwrap();
+        let step_size = 0.01;
+        let tol = 1e-4;
+
+        fn df(v: &VectorF64, g: &mut VectorF64) {
+            let x = v.get(0);
+            let y = v.get(1);
+            g.set(0, 2.0 * SCALE.0 * (x - CENTER.0));
+            g.set(1, 2.0 * SCALE.1 * (y - CENTER.1));
+        }
+
+        fn fdf(v: &VectorF64, g: &mut VectorF64) -> f64 {
+            df(v, g);
+            paraboloid(v)
+        }
+
+        let mut fs = MultiMinFdfFunction::new(paraboloid, df, fdf, 2);
+
+        min.set(&mut fs, &guess_value, step_size, tol).unwrap();
+
+        let max_iter = 100_usize;
+        let eps_abs = 0.01;
+
+        let mut status = Value::Continue;
+        let mut iter = 0_usize;
+
+        while matches!(status, Value::Continue) && iter < max_iter {
+            // iterate for next value
+            min.iterate().unwrap(); // fails here w/ segfault
+
+            status = test_gradient(&min.gradient(), eps_abs);
+
+            // check if iteration succeeded
+            if matches!(status, Value::Success) {
+                println!("Converged");
+            }
+
+            // print current iteration
+            print_fdf_state(&min, iter);
 
             iter += 1;
         }

--- a/src/types/multimin.rs
+++ b/src/types/multimin.rs
@@ -280,7 +280,7 @@ impl MinimizerFdf {
     /// Creates a minimizer of type `t` for an n-dimensional function.
     /// If there is insufficient memory to create the minimizer then
     /// the function returns a `None`.
-    #[doc(alias = "gsl_multimin_fminimizer_alloc")]
+    #[doc(alias = "gsl_multimin_fdfminimizer_alloc")]
     pub fn new(t: MinimizerFdfType, n: usize) -> Option<MinimizerFdf> {
         let ptr = unsafe { sys::gsl_multimin_fdfminimizer_alloc(t.unwrap_shared(), n) };
 


### PR DESCRIPTION
Notice I force user to provide three functions: f, df and fdf. 

We could instead have allowed fdf to be optional and internal wrapping mechanism would call user-provided f and df when GSL asks for fdf. But I left it simple for now. We can always extend? 